### PR TITLE
Add Discord bot, QE healer support, parallel jobs, and UI improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ characters.json
 payload_debug.json
 droptimizer.log
 
+# Persisted run state
+last_run.json
+
 # Python
 __pycache__/
 *.pyc

--- a/app.py
+++ b/app.py
@@ -7,12 +7,10 @@ import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
-import requests as req_lib
 from flask import Flask, jsonify, request, render_template
 
 from droptimizer import (
     RAIDBOTS_BASE,
-    RAIDBOTS_HEADERS,
     apply_talent,
     build_payload,
     find_talent_builds,
@@ -22,6 +20,7 @@ from droptimizer import (
     poll_job,
     submit_job,
 )
+from raidbots_session import make_raidbots_session
 from qe_sim import is_healer, run_qe_upgradefinder
 
 app = Flask(__name__)
@@ -141,13 +140,6 @@ _SPEC_ID_TO_NAME: dict[int, str] = {
 _VALID_SPEC_NAMES: set[str] = set(_SPEC_ID_TO_NAME.values())
 
 
-def _make_session(raidsid: str) -> req_lib.Session:
-    s = req_lib.Session()
-    s.headers.update(RAIDBOTS_HEADERS)
-    if raidsid:
-        s.cookies.set("raidsid", raidsid, domain="www.raidbots.com")
-    return s
-
 
 def _run_one(job: dict, char: dict, raidsid: str,
              encounter_items: list, instances: list, frontend_version: str) -> None:
@@ -180,7 +172,7 @@ def _run_one(job: dict, char: dict, raidsid: str,
         return
 
     # ── DPS / Tank: use Raidbots Droptimizer ────────────────────────────────
-    session = _make_session(raidsid)
+    session = make_raidbots_session(raidsid)
 
     _update_job(jid, status="fetching")
     _log(f"[{tag}] Fetching character from armory...")
@@ -243,7 +235,7 @@ def _run_one(job: dict, char: dict, raidsid: str,
 
 def _run(jobs: list, chars_by_id: dict, raidsid: str) -> None:
     try:
-        init_session = _make_session(raidsid)
+        init_session = make_raidbots_session(raidsid)
 
         _log("Fetching static data...")
         static_hash, frontend_version = get_site_versions(init_session)
@@ -398,11 +390,7 @@ def api_get_ilvl(char_id):
         return jsonify({"ilvl": char["ilvl"]})
     # Fetch from armory
     try:
-        session = req_lib.Session()
-        session.headers.update(RAIDBOTS_HEADERS)
-        raidsid = load_raidsid()
-        if raidsid:
-            session.cookies.set("raidsid", raidsid, domain="www.raidbots.com")
+        session = make_raidbots_session(load_raidsid())
         data = fetch_character(session, char["region"], char["realm"], char["name"])
         ilvl = _calc_ilvl(data.get("items", {}))
         if ilvl:

--- a/app.py
+++ b/app.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """app.py — Auto Sim web interface"""
 
-import copy
 import json
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -21,6 +20,7 @@ from droptimizer import (
 from payload_builder import CharacterIdentity, SimTarget, build_payload
 from raidbots_session import make_raidbots_session
 from sim_router import is_healer, run_qe_sim, run_raidbots_sim
+from job_state import Job, JobStatus, SimRunnerState
 
 app = Flask(__name__)
 
@@ -33,30 +33,12 @@ REPORT_URL    = RAIDBOTS_BASE + "/simbot/report/{sim_id}"
 # Global run state
 # ---------------------------------------------------------------------------
 
-def _load_last_run() -> dict:
-    if LAST_RUN_PATH.exists():
-        try:
-            return json.loads(LAST_RUN_PATH.read_text())
-        except Exception:
-            pass
-    return {"jobs": [], "log": []}
-
-_prior = _load_last_run()
-_state: dict = {"running": False, "jobs": _prior["jobs"], "log": _prior["log"]}
-_lock = threading.Lock()
+state = SimRunnerState(LAST_RUN_PATH)
 
 
 def _log(msg: str) -> None:
-    with _lock:
-        _state["log"].append(msg)
+    state.append_log(msg)
 
-
-def _update_job(job_id: str, **kw) -> None:
-    with _lock:
-        for j in _state["jobs"]:
-            if j["id"] == job_id:
-                j.update(kw)
-                break
 
 
 # ---------------------------------------------------------------------------
@@ -140,50 +122,50 @@ _VALID_SPEC_NAMES: set[str] = set(_SPEC_ID_TO_NAME.values())
 
 
 
-def _run_one(job: dict, char: dict, raidsid: str, static) -> None:
-    jid     = job["id"]
-    tag     = job["label"]
+def _run_one(job: Job, char: dict, raidsid: str, static) -> None:
+    jid     = job.id
+    tag     = job.label
     spec_id = char.get("spec_id", 63)
 
     # ── Healer: use QE Upgrade Finder (one combined Heroic+Mythic report) ────
     if is_healer(spec_id):
         # QE runs both difficulties in one session; only process the heroic job
         # and skip the mythic duplicate to avoid running the browser twice.
-        if job.get("difficulty") != "raid-heroic":
-            _update_job(jid, status="done")   # mark mythic twin as done silently
+        if job.difficulty != "raid-heroic":
+            state.transition(jid, JobStatus.SKIPPED)
             return
 
         simc = char["simc_string"]
-        if job.get("talent_code"):
-            simc = apply_talent(simc, job["talent_code"])
+        if job.talent_code:
+            simc = apply_talent(simc, job.talent_code)
 
-        _update_job(jid, status="running")
+        state.transition(jid, JobStatus.RUNNING)
         _log(f"[{tag}] Running QE Upgrade Finder (Heroic + Mythic)...")
         result = run_qe_sim(simc)
         if result.ok:
             _log(f"[{tag}] Done.")
-            _update_job(jid, status="done", url=result.url,
-                        label=tag.replace("– Heroic", "– Heroic + Mythic"))
+            state.transition(jid, JobStatus.DONE, url=result.url,
+                             label=tag.replace("– Heroic", "– Heroic + Mythic"))
         else:
             _log(f"[{tag}] QE failed: {result.error}")
-            _update_job(jid, status="failed")
+            state.transition(jid, JobStatus.FAILED)
         return
 
     # ── DPS / Tank: use Raidbots Droptimizer ────────────────────────────────
     session = make_raidbots_session(raidsid)
 
-    _update_job(jid, status="fetching")
+    state.transition(jid, JobStatus.FETCHING)
     _log(f"[{tag}] Fetching character from armory...")
     try:
         character = fetch_character(session, char["region"], char["realm"], char["name"])
     except Exception as e:
         _log(f"[{tag}] Character fetch failed: {e}")
-        _update_job(jid, status="failed")
+        state.transition(jid, JobStatus.FAILED)
         return
 
     simc = char["simc_string"]
-    if job.get("talent_code"):
-        simc = apply_talent(simc, job["talent_code"])
+    if job.talent_code:
+        simc = apply_talent(simc, job.talent_code)
 
     # Derive the canonical spec name from spec_id if char["spec"] is not a
     # recognised Raidbots spec name (e.g. it was accidentally set to the
@@ -198,36 +180,36 @@ def _run_one(job: dict, char: dict, raidsid: str, static) -> None:
         spec_label=spec_name, simc_string=simc,
     )
     target = SimTarget(
-        difficulty=job["difficulty"],
+        difficulty=job.difficulty,
         spec_id=spec_id,
         loot_spec_id=char.get("loot_spec_id", spec_id),
         crafted_stats=char.get("crafted_stats", "36/49"),
     )
 
-    _update_job(jid, status="submitting")
+    state.transition(jid, JobStatus.SUBMITTING)
     _log(f"[{tag}] Submitting...")
     try:
         payload   = build_payload(identity, target, character, static)
         sim_id, _ = submit_job(session, payload, None)
     except Exception as e:
         _log(f"[{tag}] Submit failed: {e}")
-        _update_job(jid, status="failed")
+        state.transition(jid, JobStatus.FAILED)
         return
 
-    _update_job(jid, status="running", sim_id=sim_id)
+    state.transition(jid, JobStatus.RUNNING, sim_id=sim_id)
     _log(f"[{tag}] Running ({sim_id})...")
 
     ok  = poll_job(session, sim_id, timeout_minutes=30)
     url = REPORT_URL.format(sim_id=sim_id)
     if ok:
         _log(f"[{tag}] Done.")
-        _update_job(jid, status="done", url=url)
+        state.transition(jid, JobStatus.DONE, url=url)
     else:
         _log(f"[{tag}] Failed or timed out.")
-        _update_job(jid, status="failed", url=url)
+        state.transition(jid, JobStatus.FAILED, url=url)
 
 
-def _run(jobs: list, chars_by_id: dict, raidsid: str) -> None:
+def _run(jobs: list[Job], chars_by_id: dict, raidsid: str) -> None:
     try:
         init_session = make_raidbots_session(raidsid)
 
@@ -237,7 +219,7 @@ def _run(jobs: list, chars_by_id: dict, raidsid: str) -> None:
 
         with ThreadPoolExecutor(max_workers=len(jobs)) as pool:
             futures = {
-                pool.submit(_run_one, job, chars_by_id[job["char_id"]], raidsid, static): job
+                pool.submit(_run_one, job, chars_by_id[job.char_id], raidsid, static): job
                 for job in jobs
             }
             for future in as_completed(futures):
@@ -245,20 +227,13 @@ def _run(jobs: list, chars_by_id: dict, raidsid: str) -> None:
                     future.result()
                 except Exception as e:
                     job = futures[future]
-                    _log(f"[{job['label']}] Unexpected error: {e}")
+                    _log(f"[{job.label}] Unexpected error: {e}")
 
     except Exception as e:
         _log(f"Unexpected error: {e}")
     finally:
-        with _lock:
-            _state["running"] = False
         _log("— finished —")
-        with _lock:
-            snapshot = {"jobs": list(_state["jobs"]), "log": list(_state["log"])}
-        try:
-            LAST_RUN_PATH.write_text(json.dumps(snapshot, indent=2))
-        except Exception:
-            pass
+        state.finish_run()
 
 
 # ---------------------------------------------------------------------------
@@ -408,15 +383,11 @@ def api_save_settings():
 
 @app.post("/api/run")
 def api_run():
-    with _lock:
-        if _state["running"]:
-            return jsonify({"error": "Already running"}), 409
-
     selections  = request.json.get("selections", [])
     chars_all   = load_characters()
     chars_by_id = {c["id"]: c for c in chars_all}
 
-    jobs = []
+    jobs: list[Job] = []
     for sel in selections:
         char = chars_by_id.get(sel["char_id"])
         if not char:
@@ -433,24 +404,21 @@ def api_run():
                 diff_label   = "Heroic" if diff == "raid-heroic" else "Mythic"
                 build_suffix = f" \u2013 {build_label}" if build_label else ""
                 job_id       = f"{sel['char_id']}-{build_label.lower() or 'default'}-{diff}"
-                jobs.append({
-                    "id":           job_id,
-                    "char_id":      sel["char_id"],
-                    "label":        f"{char['name']} \u2013 {char['spec']}{build_suffix} \u2013 {diff_label}",
-                    "difficulty":   diff,
-                    "talent_code":  talent_code,
-                    "status":       "pending",
-                    "sim_id":       None,
-                    "url":          None,
-                })
+                jobs.append(Job(
+                    id=job_id,
+                    char_id=sel["char_id"],
+                    label=f"{char['name']} \u2013 {char['spec']}{build_suffix} \u2013 {diff_label}",
+                    difficulty=diff,
+                    talent_code=talent_code,
+                ))
 
     if not jobs:
         return jsonify({"error": "Nothing selected"}), 400
 
-    with _lock:
-        _state["running"] = True
-        _state["jobs"]    = jobs
-        _state["log"]     = []
+    try:
+        state.start_run(jobs)
+    except RuntimeError:
+        return jsonify({"error": "Already running"}), 409
 
     threading.Thread(target=_run, args=(jobs, chars_by_id, load_raidsid()), daemon=True).start()
     return jsonify({"ok": True})
@@ -458,12 +426,7 @@ def api_run():
 
 @app.get("/api/status")
 def api_status():
-    with _lock:
-        return jsonify({
-            "running": _state["running"],
-            "jobs":    copy.deepcopy(_state["jobs"]),
-            "log":     list(_state["log"]),
-        })
+    return jsonify(state.snapshot())
 
 
 if __name__ == "__main__":

--- a/app.py
+++ b/app.py
@@ -14,10 +14,8 @@ from droptimizer import (
     fetch_character,
     fetch_static_data,
     find_talent_builds,
-    poll_job,
-    submit_job,
 )
-from payload_builder import CharacterIdentity, SimTarget, build_payload
+from payload_builder import CharacterIdentity, SimTarget
 from raidbots_session import make_raidbots_session
 from sim_router import is_healer, run_qe_sim, run_raidbots_sim
 from job_state import Job, JobStatus, SimRunnerState
@@ -186,27 +184,26 @@ def _run_one(job: Job, char: dict, raidsid: str, static) -> None:
         crafted_stats=char.get("crafted_stats", "36/49"),
     )
 
+    def _on_submitted(sim_id: str) -> None:
+        state.transition(jid, JobStatus.RUNNING, sim_id=sim_id)
+        _log(f"[{tag}] Running ({sim_id})...")
+
     state.transition(jid, JobStatus.SUBMITTING)
     _log(f"[{tag}] Submitting...")
-    try:
-        payload   = build_payload(identity, target, character, static)
-        sim_id, _ = submit_job(session, payload, None)
-    except Exception as e:
-        _log(f"[{tag}] Submit failed: {e}")
-        state.transition(jid, JobStatus.FAILED)
-        return
-
-    state.transition(jid, JobStatus.RUNNING, sim_id=sim_id)
-    _log(f"[{tag}] Running ({sim_id})...")
-
-    ok  = poll_job(session, sim_id, timeout_minutes=30)
-    url = REPORT_URL.format(sim_id=sim_id)
-    if ok:
+    result = run_raidbots_sim(
+        session, identity, target, character, static,
+        report_url_template=REPORT_URL,
+        timeout_minutes=30,
+        on_submitted=_on_submitted,
+    )
+    if result.ok:
         _log(f"[{tag}] Done.")
-        state.transition(jid, JobStatus.DONE, url=url)
+        state.transition(jid, JobStatus.DONE, url=result.url)
     else:
+        if result.error:
+            _log(f"[{tag}] {result.error}")
         _log(f"[{tag}] Failed or timed out.")
-        state.transition(jid, JobStatus.FAILED, url=url)
+        state.transition(jid, JobStatus.FAILED, url=result.url or "")
 
 
 def _run(jobs: list[Job], chars_by_id: dict, raidsid: str) -> None:

--- a/app.py
+++ b/app.py
@@ -20,7 +20,7 @@ from droptimizer import (
 )
 from payload_builder import CharacterIdentity, SimTarget, build_payload
 from raidbots_session import make_raidbots_session
-from qe_sim import is_healer, run_qe_upgradefinder
+from sim_router import is_healer, run_qe_sim, run_raidbots_sim
 
 app = Flask(__name__)
 
@@ -159,13 +159,13 @@ def _run_one(job: dict, char: dict, raidsid: str, static) -> None:
 
         _update_job(jid, status="running")
         _log(f"[{tag}] Running QE Upgrade Finder (Heroic + Mythic)...")
-        try:
-            url = run_qe_upgradefinder(simc)
+        result = run_qe_sim(simc)
+        if result.ok:
             _log(f"[{tag}] Done.")
-            _update_job(jid, status="done", url=url,
+            _update_job(jid, status="done", url=result.url,
                         label=tag.replace("– Heroic", "– Heroic + Mythic"))
-        except Exception as e:
-            _log(f"[{tag}] QE failed: {e}")
+        else:
+            _log(f"[{tag}] QE failed: {result.error}")
             _update_job(jid, status="failed")
         return
 

--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@
 import copy
 import json
 import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 import requests as req_lib
@@ -21,18 +22,29 @@ from droptimizer import (
     poll_job,
     submit_job,
 )
+from qe_sim import is_healer, run_qe_upgradefinder
 
 app = Flask(__name__)
 
-CHARS_PATH  = Path(__file__).parent / "characters.json"
-CONFIG_PATH = Path(__file__).parent / "config.json"
-REPORT_URL  = RAIDBOTS_BASE + "/simbot/report/{sim_id}"
+CHARS_PATH    = Path(__file__).parent / "characters.json"
+CONFIG_PATH   = Path(__file__).parent / "config.json"
+LAST_RUN_PATH = Path(__file__).parent / "last_run.json"
+REPORT_URL    = RAIDBOTS_BASE + "/simbot/report/{sim_id}"
 
 # ---------------------------------------------------------------------------
 # Global run state
 # ---------------------------------------------------------------------------
 
-_state: dict = {"running": False, "jobs": [], "log": []}
+def _load_last_run() -> dict:
+    if LAST_RUN_PATH.exists():
+        try:
+            return json.loads(LAST_RUN_PATH.read_text())
+        except Exception:
+            pass
+    return {"jobs": [], "log": []}
+
+_prior = _load_last_run()
+_state: dict = {"running": False, "jobs": _prior["jobs"], "log": _prior["log"]}
 _lock = threading.Lock()
 
 
@@ -109,78 +121,152 @@ def save_raidsid(raidsid: str) -> None:
 # Background sim runner
 # ---------------------------------------------------------------------------
 
+# spec_id → Raidbots spec name (used as fallback when char["spec"] is wrong)
+_SPEC_ID_TO_NAME: dict[int, str] = {
+    62: "Arcane", 63: "Fire", 64: "Frost",
+    65: "Holy", 66: "Protection", 70: "Retribution",
+    71: "Arms", 72: "Fury", 73: "Protection",
+    102: "Balance", 103: "Feral", 104: "Guardian", 105: "Restoration",
+    250: "Blood", 251: "Frost", 252: "Unholy",
+    253: "BeastMastery", 254: "Marksmanship", 255: "Survival",
+    256: "Discipline", 257: "Holy", 258: "Shadow",
+    259: "Assassination", 260: "Outlaw", 261: "Subtlety",
+    262: "Elemental", 263: "Enhancement", 264: "Restoration",
+    265: "Affliction", 266: "Demonology", 267: "Destruction",
+    268: "Brewmaster", 269: "Windwalker", 270: "Mistweaver",
+    577: "Havoc", 581: "Vengeance", 1480: "Devourer",
+    1467: "Devastation", 1468: "Preservation", 1473: "Augmentation",
+}
+
+_VALID_SPEC_NAMES: set[str] = set(_SPEC_ID_TO_NAME.values())
+
+
+def _make_session(raidsid: str) -> req_lib.Session:
+    s = req_lib.Session()
+    s.headers.update(RAIDBOTS_HEADERS)
+    if raidsid:
+        s.cookies.set("raidsid", raidsid, domain="www.raidbots.com")
+    return s
+
+
+def _run_one(job: dict, char: dict, raidsid: str,
+             encounter_items: list, instances: list, frontend_version: str) -> None:
+    jid     = job["id"]
+    tag     = job["label"]
+    spec_id = char.get("spec_id", 63)
+
+    # ── Healer: use QE Upgrade Finder (one combined Heroic+Mythic report) ────
+    if is_healer(spec_id):
+        # QE runs both difficulties in one session; only process the heroic job
+        # and skip the mythic duplicate to avoid running the browser twice.
+        if job.get("difficulty") != "raid-heroic":
+            _update_job(jid, status="done")   # mark mythic twin as done silently
+            return
+
+        simc = char["simc_string"]
+        if job.get("talent_code"):
+            simc = apply_talent(simc, job["talent_code"])
+
+        _update_job(jid, status="running")
+        _log(f"[{tag}] Running QE Upgrade Finder (Heroic + Mythic)...")
+        try:
+            url = run_qe_upgradefinder(simc)
+            _log(f"[{tag}] Done.")
+            _update_job(jid, status="done", url=url,
+                        label=tag.replace("– Heroic", "– Heroic + Mythic"))
+        except Exception as e:
+            _log(f"[{tag}] QE failed: {e}")
+            _update_job(jid, status="failed")
+        return
+
+    # ── DPS / Tank: use Raidbots Droptimizer ────────────────────────────────
+    session = _make_session(raidsid)
+
+    _update_job(jid, status="fetching")
+    _log(f"[{tag}] Fetching character from armory...")
+    try:
+        character = fetch_character(session, char["region"], char["realm"], char["name"])
+    except Exception as e:
+        _log(f"[{tag}] Character fetch failed: {e}")
+        _update_job(jid, status="failed")
+        return
+
+    simc = char["simc_string"]
+    if job.get("talent_code"):
+        simc = apply_talent(simc, job["talent_code"])
+
+    cfg_wrap = {
+        "character":   {"name": char["name"], "realm": char["realm"], "region": char["region"]},
+        "simc_string": simc,
+    }
+    # Derive the canonical spec name from spec_id if char["spec"] is not a
+    # recognised Raidbots spec name (e.g. it was accidentally set to the
+    # character name).
+    spec_name = char["spec"].capitalize()
+    if spec_name not in _VALID_SPEC_NAMES:
+        spec_name = _SPEC_ID_TO_NAME.get(spec_id, "Fire")
+        _log(f"[{tag}] Spec '{char['spec']}' unrecognised — using '{spec_name}' from spec_id {spec_id}.")
+
+    run_opts = {
+        "difficulty":    job["difficulty"],
+        "instance_id":   -91,
+        "spec":          spec_name,
+        "spec_id":       spec_id,
+        "loot_spec_id":  char.get("loot_spec_id", spec_id),
+        "fight_style":   "Patchwerk",
+        "iterations":    "smart",
+        "crafted_stats": char.get("crafted_stats", "36/49"),
+    }
+
+    _update_job(jid, status="submitting")
+    _log(f"[{tag}] Submitting...")
+    try:
+        payload   = build_payload(cfg_wrap, run_opts, character, encounter_items, instances, frontend_version)
+        sim_id, _ = submit_job(session, payload, None)
+    except Exception as e:
+        _log(f"[{tag}] Submit failed: {e}")
+        _update_job(jid, status="failed")
+        return
+
+    _update_job(jid, status="running", sim_id=sim_id)
+    _log(f"[{tag}] Running ({sim_id})...")
+
+    ok  = poll_job(session, sim_id, timeout_minutes=30)
+    url = REPORT_URL.format(sim_id=sim_id)
+    if ok:
+        _log(f"[{tag}] Done.")
+        _update_job(jid, status="done", url=url)
+    else:
+        _log(f"[{tag}] Failed or timed out.")
+        _update_job(jid, status="failed", url=url)
+
+
 def _run(jobs: list, chars_by_id: dict, raidsid: str) -> None:
     try:
-        session = req_lib.Session()
-        session.headers.update(RAIDBOTS_HEADERS)
-        if raidsid:
-            session.cookies.set("raidsid", raidsid, domain="www.raidbots.com")
+        init_session = _make_session(raidsid)
 
         _log("Fetching static data...")
-        static_hash, frontend_version = get_site_versions(session)
+        static_hash, frontend_version = get_site_versions(init_session)
 
         _log("Fetching encounter items...")
-        encounter_items = fetch_encounter_items(session, static_hash)
+        encounter_items = fetch_encounter_items(init_session, static_hash)
 
-        resp      = session.get(f"{RAIDBOTS_BASE}/static/data/{static_hash}/instances.json", timeout=15)
+        resp      = init_session.get(f"{RAIDBOTS_BASE}/static/data/{static_hash}/instances.json", timeout=15)
         instances = resp.json()
-        _log(f"Ready — {len(jobs)} job(s) queued.")
+        _log(f"Ready — {len(jobs)} job(s) queued, running in parallel.")
 
-        for job in jobs:
-            char = chars_by_id[job["char_id"]]
-            jid  = job["id"]
-            tag  = job["label"]
-
-            _update_job(jid, status="fetching")
-            _log(f"[{tag}] Fetching character from armory...")
-            try:
-                character = fetch_character(session, char["region"], char["realm"], char["name"])
-            except Exception as e:
-                _log(f"[{tag}] Character fetch failed: {e}")
-                _update_job(jid, status="failed")
-                continue
-
-            # Use talent-build-specific simc if the job specifies one
-            simc = char["simc_string"]
-            if job.get("talent_code"):
-                simc = apply_talent(simc, job["talent_code"])
-
-            cfg_wrap = {
-                "character":   {"name": char["name"], "realm": char["realm"], "region": char["region"]},
-                "simc_string": simc,
+        with ThreadPoolExecutor(max_workers=len(jobs)) as pool:
+            futures = {
+                pool.submit(_run_one, job, chars_by_id[job["char_id"]], raidsid,
+                            encounter_items, instances, frontend_version): job
+                for job in jobs
             }
-            run_opts = {
-                "difficulty":    job["difficulty"],
-                "instance_id":   -91,
-                "spec":          char["spec"],
-                "spec_id":       char.get("spec_id", 63),
-                "loot_spec_id":  char.get("loot_spec_id", char.get("spec_id", 63)),
-                "fight_style":   "Patchwerk",
-                "iterations":    "smart",
-                "crafted_stats": char.get("crafted_stats", "36/49"),
-            }
-
-            _update_job(jid, status="submitting")
-            _log(f"[{tag}] Submitting...")
-            try:
-                payload        = build_payload(cfg_wrap, run_opts, character, encounter_items, instances, frontend_version)
-                sim_id, _      = submit_job(session, payload, None)
-            except Exception as e:
-                _log(f"[{tag}] Submit failed: {e}")
-                _update_job(jid, status="failed")
-                continue
-
-            _update_job(jid, status="running", sim_id=sim_id)
-            _log(f"[{tag}] Running ({sim_id})...")
-
-            ok  = poll_job(session, sim_id, timeout_minutes=30)
-            url = REPORT_URL.format(sim_id=sim_id)
-            if ok:
-                _log(f"[{tag}] Done.")
-                _update_job(jid, status="done", url=url)
-            else:
-                _log(f"[{tag}] Failed or timed out.")
-                _update_job(jid, status="failed", url=url)
+            for future in as_completed(futures):
+                try:
+                    future.result()
+                except Exception as e:
+                    job = futures[future]
+                    _log(f"[{job['label']}] Unexpected error: {e}")
 
     except Exception as e:
         _log(f"Unexpected error: {e}")
@@ -188,6 +274,82 @@ def _run(jobs: list, chars_by_id: dict, raidsid: str) -> None:
         with _lock:
             _state["running"] = False
         _log("— finished —")
+        with _lock:
+            snapshot = {"jobs": list(_state["jobs"]), "log": list(_state["log"])}
+        try:
+            LAST_RUN_PATH.write_text(json.dumps(snapshot, indent=2))
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_GEAR_SLOTS = ["head", "neck", "shoulder", "back", "chest", "wrist", "hands",
+               "waist", "legs", "feet", "finger1", "finger2",
+               "trinket1", "trinket2", "mainHand", "offHand"]
+
+def _calc_ilvl(items: dict) -> float | None:
+    """Calculate average equipped ilvl with 2 dp, counting 2H weapons twice."""
+    if not items:
+        return None
+    total, count = 0, 0
+    main = items.get("mainHand")
+    for slot in _GEAR_SLOTS:
+        item = items.get(slot)
+        if slot == "offHand" and item is None and isinstance(main, dict) and main.get("inventoryType") == 17:
+            item = main  # 2H weapon fills the off-hand slot too
+        if isinstance(item, dict) and item.get("itemLevel"):
+            total += item["itemLevel"]
+            count += 1
+    if count != 16:
+        return None
+    return round(total / 16, 2)
+
+
+_SIMC_GEAR_SLOTS = {
+    "head", "neck", "shoulder", "back", "chest", "wrist", "hands",
+    "waist", "legs", "feet", "finger1", "finger2",
+    "trinket1", "trinket2", "main_hand", "off_hand",
+}
+
+def _simc_gear_lines(simc: str) -> list[str]:
+    return [l for l in simc.splitlines()
+            if l.split("=")[0].strip() in _SIMC_GEAR_SLOTS]
+
+def _replace_simc_gear(simc: str, new_gear: list[str]) -> str:
+    non_gear = [l for l in simc.splitlines()
+                if l.split("=")[0].strip() not in _SIMC_GEAR_SLOTS]
+    body = "\n".join(non_gear).rstrip()
+    return body + "\n\n" + "\n".join(new_gear)
+
+def _propagate_gear(updated: dict, chars: list) -> list[str]:
+    """Push gear from `updated` to same-name profiles. Returns list of updated ids."""
+    new_gear = _simc_gear_lines(updated.get("simc_string", ""))
+    if not new_gear:
+        return []
+    updated_name = updated.get("name", "").lower()
+    updated_ilvl  = updated.get("ilvl")
+    changed = []
+    for c in chars:
+        if c["id"] == updated["id"]:
+            continue
+        if c.get("name", "").lower() != updated_name:
+            continue
+        if c.get("exclude_from_item_updates"):
+            continue
+        existing_ilvl = c.get("ilvl")
+        # Only propagate if ilvl differs (or either side has no ilvl cached)
+        if updated_ilvl and existing_ilvl and updated_ilvl == existing_ilvl:
+            continue
+        old_gear = _simc_gear_lines(c.get("simc_string", ""))
+        if old_gear == new_gear:
+            continue
+        c["simc_string"] = _replace_simc_gear(c["simc_string"], new_gear)
+        c["ilvl"] = updated_ilvl  # carry over cached ilvl
+        changed.append(c["id"])
+    return changed
 
 
 # ---------------------------------------------------------------------------
@@ -214,14 +376,44 @@ def api_upsert_character():
         chars[idx] = char
     else:
         chars.append(char)
+    propagated = _propagate_gear(char, chars)
     save_characters(chars)
-    return jsonify(char)
+    return jsonify({"char": char, "propagated": propagated})
 
 
 @app.delete("/api/characters/<char_id>")
 def api_delete_character(char_id):
     save_characters([c for c in load_characters() if c["id"] != char_id])
     return jsonify({"ok": True})
+
+
+@app.get("/api/ilvl/<char_id>")
+def api_get_ilvl(char_id):
+    chars = load_characters()
+    char  = next((c for c in chars if c["id"] == char_id), None)
+    if not char:
+        return jsonify({"error": "not found"}), 404
+    # Return cached value if already stored
+    if char.get("ilvl"):
+        return jsonify({"ilvl": char["ilvl"]})
+    # Fetch from armory
+    try:
+        session = req_lib.Session()
+        session.headers.update(RAIDBOTS_HEADERS)
+        raidsid = load_raidsid()
+        if raidsid:
+            session.cookies.set("raidsid", raidsid, domain="www.raidbots.com")
+        data = fetch_character(session, char["region"], char["realm"], char["name"])
+        ilvl = _calc_ilvl(data.get("items", {}))
+        if ilvl:
+            # Cache in character profile
+            for c in chars:
+                if c["id"] == char_id:
+                    c["ilvl"] = ilvl
+            save_characters(chars)
+        return jsonify({"ilvl": ilvl})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
 
 
 @app.get("/api/settings")
@@ -301,5 +493,16 @@ def api_status():
 
 if __name__ == "__main__":
     import webbrowser, threading as _t
+
+    # Start Discord bot if token is configured
+    try:
+        import discord_bot as _db
+        _cfg = json.loads(CONFIG_PATH.read_text()) if CONFIG_PATH.exists() else {}
+        _bot_token = _cfg.get("discord_bot_token")
+        if _bot_token:
+            _t.Thread(target=_db.start, args=(_bot_token,), daemon=True).start()
+    except Exception as _e:
+        print(f"[discord] Bot not started: {_e}")
+
     _t.Timer(0.8, lambda: webbrowser.open("http://localhost:5000")).start()
     app.run(debug=False, port=5000, use_reloader=False)

--- a/app.py
+++ b/app.py
@@ -12,14 +12,13 @@ from flask import Flask, jsonify, request, render_template
 from droptimizer import (
     RAIDBOTS_BASE,
     apply_talent,
-    build_payload,
-    find_talent_builds,
     fetch_character,
-    fetch_encounter_items,
-    get_site_versions,
+    fetch_static_data,
+    find_talent_builds,
     poll_job,
     submit_job,
 )
+from payload_builder import CharacterIdentity, SimTarget, build_payload
 from raidbots_session import make_raidbots_session
 from qe_sim import is_healer, run_qe_upgradefinder
 
@@ -141,8 +140,7 @@ _VALID_SPEC_NAMES: set[str] = set(_SPEC_ID_TO_NAME.values())
 
 
 
-def _run_one(job: dict, char: dict, raidsid: str,
-             encounter_items: list, instances: list, frontend_version: str) -> None:
+def _run_one(job: dict, char: dict, raidsid: str, static) -> None:
     jid     = job["id"]
     tag     = job["label"]
     spec_id = char.get("spec_id", 63)
@@ -187,10 +185,6 @@ def _run_one(job: dict, char: dict, raidsid: str,
     if job.get("talent_code"):
         simc = apply_talent(simc, job["talent_code"])
 
-    cfg_wrap = {
-        "character":   {"name": char["name"], "realm": char["realm"], "region": char["region"]},
-        "simc_string": simc,
-    }
     # Derive the canonical spec name from spec_id if char["spec"] is not a
     # recognised Raidbots spec name (e.g. it was accidentally set to the
     # character name).
@@ -199,21 +193,21 @@ def _run_one(job: dict, char: dict, raidsid: str,
         spec_name = _SPEC_ID_TO_NAME.get(spec_id, "Fire")
         _log(f"[{tag}] Spec '{char['spec']}' unrecognised — using '{spec_name}' from spec_id {spec_id}.")
 
-    run_opts = {
-        "difficulty":    job["difficulty"],
-        "instance_id":   -91,
-        "spec":          spec_name,
-        "spec_id":       spec_id,
-        "loot_spec_id":  char.get("loot_spec_id", spec_id),
-        "fight_style":   "Patchwerk",
-        "iterations":    "smart",
-        "crafted_stats": char.get("crafted_stats", "36/49"),
-    }
+    identity = CharacterIdentity(
+        name=char["name"], realm=char["realm"], region=char["region"],
+        spec_label=spec_name, simc_string=simc,
+    )
+    target = SimTarget(
+        difficulty=job["difficulty"],
+        spec_id=spec_id,
+        loot_spec_id=char.get("loot_spec_id", spec_id),
+        crafted_stats=char.get("crafted_stats", "36/49"),
+    )
 
     _update_job(jid, status="submitting")
     _log(f"[{tag}] Submitting...")
     try:
-        payload   = build_payload(cfg_wrap, run_opts, character, encounter_items, instances, frontend_version)
+        payload   = build_payload(identity, target, character, static)
         sim_id, _ = submit_job(session, payload, None)
     except Exception as e:
         _log(f"[{tag}] Submit failed: {e}")
@@ -238,19 +232,12 @@ def _run(jobs: list, chars_by_id: dict, raidsid: str) -> None:
         init_session = make_raidbots_session(raidsid)
 
         _log("Fetching static data...")
-        static_hash, frontend_version = get_site_versions(init_session)
-
-        _log("Fetching encounter items...")
-        encounter_items = fetch_encounter_items(init_session, static_hash)
-
-        resp      = init_session.get(f"{RAIDBOTS_BASE}/static/data/{static_hash}/instances.json", timeout=15)
-        instances = resp.json()
+        static = fetch_static_data(init_session)
         _log(f"Ready — {len(jobs)} job(s) queued, running in parallel.")
 
         with ThreadPoolExecutor(max_workers=len(jobs)) as pool:
             futures = {
-                pool.submit(_run_one, job, chars_by_id[job["char_id"]], raidsid,
-                            encounter_items, instances, frontend_version): job
+                pool.submit(_run_one, job, chars_by_id[job["char_id"]], raidsid, static): job
                 for job in jobs
             }
             for future in as_completed(futures):

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -2,40 +2,15 @@
 
 import asyncio
 import json
-import re
-import concurrent.futures
 from pathlib import Path
 
 import discord
 from discord import app_commands
 
-from droptimizer import (
-    RAIDBOTS_BASE,
-    apply_talent, fetch_character, fetch_static_data, find_talent_builds,
-)
-from payload_builder import CharacterIdentity, SimTarget
-from raidbots_session import make_raidbots_session
-from sim_router import is_healer, run_qe_sim, run_raidbots_sim
+from simulation_runner import RunnerConfig, SimulationRunner
 
 CONFIG_PATH = Path(__file__).parent / "config.json"
 CHARS_PATH  = Path(__file__).parent / "characters.json"
-REPORT_URL  = RAIDBOTS_BASE + "/simbot/report/{sim_id}"
-
-SPEC_IDS: dict[str, dict[str, int]] = {
-    "death_knight": {"blood": 250, "frost": 251, "unholy": 252},
-    "demon_hunter": {"havoc": 577, "vengeance": 581, "devourer": 1480},
-    "druid":        {"balance": 102, "feral": 103, "guardian": 104, "restoration": 105},
-    "evoker":       {"devastation": 1467, "preservation": 1468, "augmentation": 1473},
-    "hunter":       {"beast_mastery": 253, "marksmanship": 254, "survival": 255},
-    "mage":         {"arcane": 62, "fire": 63, "frost": 64},
-    "monk":         {"brewmaster": 268, "mistweaver": 270, "windwalker": 269},
-    "paladin":      {"holy": 65, "protection": 66, "retribution": 70},
-    "priest":       {"discipline": 256, "holy": 257, "shadow": 258},
-    "rogue":        {"assassination": 259, "outlaw": 260, "subtlety": 261},
-    "shaman":       {"elemental": 262, "enhancement": 263, "restoration": 264},
-    "warlock":      {"affliction": 265, "demonology": 266, "destruction": 267},
-    "warrior":      {"arms": 71, "fury": 72, "protection": 73},
-}
 
 
 # ---------------------------------------------------------------------------
@@ -58,99 +33,11 @@ def _load_characters() -> list:
     return []
 
 
-def _parse_simc(simc: str) -> dict:
-    """Extract name, char_class, region, realm, spec from a SimC string."""
-    result: dict = {}
-    for line in simc.splitlines():
-        m = re.match(r'^([\w][\w\s]*)="([^"]+)"', line)
-        if m and "char_class" not in result:
-            result["char_class"] = m.group(1).strip().lower().replace(" ", "_")
-            result["name"] = m.group(2).strip()
-        kv = re.match(r'^(\w+)\s*=\s*(.+)', line)
-        if not kv:
-            continue
-        k, v = kv.group(1), kv.group(2).strip()
-        if k == "region": result["region"] = v.lower()
-        if k == "server": result["realm"]  = v.lower()
-        if k == "spec":   result["spec"]   = v.lower()
-    return result
-
-
-
-def _run_sims(simc: str, raidsid: str) -> list[dict]:
-    """
-    Fetch static data, resolve character presets, then run all talent build ×
-    difficulty combinations in parallel.  Returns a list of result dicts.
-    """
-    info = _parse_simc(simc)
-    if not all(k in info for k in ("name", "region", "realm", "spec")):
-        raise ValueError("Could not parse name / region / realm / spec from SimC string.")
-
-    # Resolve presets from saved characters (same name + spec)
-    saved = {
-        (c["name"].lower(), c["spec"].lower()): c
-        for c in _load_characters()
-    }
-    preset = saved.get((info["name"].lower(), info["spec"].lower()))
-    spec_id       = (preset.get("spec_id")      if preset else None) or \
-                    SPEC_IDS.get(info.get("char_class", ""), {}).get(info["spec"], 63)
-    loot_spec_id  = (preset.get("loot_spec_id") if preset else None) or spec_id
-    crafted_stats = (preset.get("crafted_stats") if preset else None) or "36/49"
-    simc_final    = (preset.get("simc_string")   if preset else None) or simc
-
-    # ── Healer: use QE Upgrade Finder ───────────────────────────────────────
-    if is_healer(spec_id):
-        talent_builds = find_talent_builds(simc_final) or {"": None}
-        results = []
-
-        def _qe_one(build_label: str, talent_code: str | None) -> dict:
-            sim_simc = apply_talent(simc_final, talent_code) if talent_code else simc_final
-            label = f"Heroic + Mythic{' – ' + build_label if build_label else ''}"
-            r = run_qe_sim(sim_simc, label=label)
-            return {"label": r.label, "url": r.url, "ok": r.ok, "error": r.error}
-
-        with concurrent.futures.ThreadPoolExecutor(max_workers=len(talent_builds)) as pool:
-            futures = [pool.submit(_qe_one, bl, tc) for bl, tc in talent_builds.items()]
-            results = [f.result() for f in concurrent.futures.as_completed(futures)]
-        return results
-
-    # ── DPS / Tank: use Raidbots Droptimizer ────────────────────────────────
-    init_session = make_raidbots_session(raidsid)
-    static    = fetch_static_data(init_session)
-    character = fetch_character(init_session, info["region"], info["realm"], info["name"])
-
-    # Build job list
-    talent_builds = find_talent_builds(simc_final) or {"": None}
-    jobs = [
-        (build_label, talent_code, difficulty)
-        for build_label, talent_code in talent_builds.items()
-        for difficulty in ("raid-heroic", "raid-mythic")
-    ]
-
-    def _one(build_label: str, talent_code: str | None, difficulty: str) -> dict:
-        s = make_raidbots_session(raidsid)
-        sim_simc = apply_talent(simc_final, talent_code) if talent_code else simc_final
-        diff_name = "Heroic" if difficulty == "raid-heroic" else "Mythic"
-        label     = f"{diff_name}{' – ' + build_label if build_label else ''}"
-        identity = CharacterIdentity(
-            name=info["name"], realm=info["realm"], region=info["region"],
-            spec_label=info["spec"].capitalize(), simc_string=sim_simc,
-        )
-        target = SimTarget(
-            difficulty=difficulty,
-            spec_id=spec_id,
-            loot_spec_id=loot_spec_id,
-            crafted_stats=crafted_stats,
-        )
-        r = run_raidbots_sim(s, identity, target, character, static,
-                             report_url_template=REPORT_URL)
-        return {"label": label, "url": r.url, "ok": r.ok}
-
-    with concurrent.futures.ThreadPoolExecutor(max_workers=len(jobs)) as pool:
-        futures = [pool.submit(_one, *j) for j in jobs]
-        results = [f.result() for f in concurrent.futures.as_completed(futures)]
-
-    return results
+def _parse_char_label(simc: str) -> str:
+    """Return a short 'Name – Spec' label from the first lines of a SimC string."""
+    from simulation_runner import parse_simc
+    info = parse_simc(simc)
+    return f"{info.get('name', '?')} \u2013 {info.get('spec', '?').capitalize()}"
 
 
 # ---------------------------------------------------------------------------
@@ -192,23 +79,22 @@ async def droptimizer_cmd(
             simc = raw.decode("utf-8")
         else:
             simc = simc_string
-        info  = _parse_simc(simc)
-        char_label = f"{info.get('name', '?')} – {info.get('spec', '?').capitalize()}"
+        char_label = _parse_char_label(simc)
     except Exception as e:
         await interaction.followup.send(f"Could not read SimC input: {e}", ephemeral=True)
         return
 
     await interaction.followup.send(
-        f"Running sims for **{char_label}**… I'll DM you the results when done.",
+        f"Running sims for **{char_label}**\u2026 I\u2019ll DM you the results when done.",
         ephemeral=True,
     )
 
     cfg     = _load_config()
-    raidsid = cfg.get("raidsid", "")
+    config  = RunnerConfig(raidsid=cfg.get("raidsid", ""))
+    runner  = SimulationRunner(config, chars_path=CHARS_PATH)
 
-    loop = asyncio.get_running_loop()
     try:
-        results = await loop.run_in_executor(None, _run_sims, simc, raidsid)
+        results = await runner.run_async(simc)
     except Exception as e:
         try:
             await interaction.user.send(f"Droptimizer failed for **{char_label}**: {e}")
@@ -216,17 +102,17 @@ async def droptimizer_cmd(
             pass
         return
 
-    lines = [f"**Droptimizer results — {char_label}**\n"]
+    lines = [f"**Droptimizer results \u2014 {char_label}**\n"]
     for r in sorted(results, key=lambda x: x["label"]):
-        status = "✅" if r["ok"] else "❌"
-        lines.append(f"{status} **{r['label']}** — {r['url']}")
+        status = "\u2705" if r["ok"] else "\u274c"
+        lines.append(f"{status} **{r['label']}** \u2014 {r['url']}")
 
     message = "\n".join(lines)
     try:
         await interaction.user.send(message)
     except discord.Forbidden:
         await interaction.followup.send(
-            "Couldn't DM you — please enable DMs from server members.\n\n" + message,
+            "Couldn\u2019t DM you \u2014 please enable DMs from server members.\n\n" + message,
             ephemeral=True,
         )
 

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -11,12 +11,11 @@ from discord import app_commands
 
 from droptimizer import (
     RAIDBOTS_BASE,
-    apply_talent, fetch_character, fetch_static_data,
-    find_talent_builds, poll_job, submit_job,
+    apply_talent, fetch_character, fetch_static_data, find_talent_builds,
 )
-from payload_builder import CharacterIdentity, SimTarget, build_payload
+from payload_builder import CharacterIdentity, SimTarget
 from raidbots_session import make_raidbots_session
-from qe_sim import is_healer, run_qe_upgradefinder
+from sim_router import is_healer, run_qe_sim, run_raidbots_sim
 
 CONFIG_PATH = Path(__file__).parent / "config.json"
 CHARS_PATH  = Path(__file__).parent / "characters.json"
@@ -107,11 +106,8 @@ def _run_sims(simc: str, raidsid: str) -> list[dict]:
         def _qe_one(build_label: str, talent_code: str | None) -> dict:
             sim_simc = apply_talent(simc_final, talent_code) if talent_code else simc_final
             label = f"Heroic + Mythic{' – ' + build_label if build_label else ''}"
-            try:
-                url = run_qe_upgradefinder(sim_simc)
-                return {"label": label, "url": url, "ok": True}
-            except Exception as e:
-                return {"label": label, "url": "", "ok": False, "error": str(e)}
+            r = run_qe_sim(sim_simc, label=label)
+            return {"label": r.label, "url": r.url, "ok": r.ok, "error": r.error}
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=len(talent_builds)) as pool:
             futures = [pool.submit(_qe_one, bl, tc) for bl, tc in talent_builds.items()]
@@ -134,6 +130,8 @@ def _run_sims(simc: str, raidsid: str) -> list[dict]:
     def _one(build_label: str, talent_code: str | None, difficulty: str) -> dict:
         s = make_raidbots_session(raidsid)
         sim_simc = apply_talent(simc_final, talent_code) if talent_code else simc_final
+        diff_name = "Heroic" if difficulty == "raid-heroic" else "Mythic"
+        label     = f"{diff_name}{' – ' + build_label if build_label else ''}"
         identity = CharacterIdentity(
             name=info["name"], realm=info["realm"], region=info["region"],
             spec_label=info["spec"].capitalize(), simc_string=sim_simc,
@@ -144,12 +142,9 @@ def _run_sims(simc: str, raidsid: str) -> list[dict]:
             loot_spec_id=loot_spec_id,
             crafted_stats=crafted_stats,
         )
-        payload   = build_payload(identity, target, character, static)
-        sim_id, _ = submit_job(s, payload, None)
-        ok        = poll_job(s, sim_id, timeout_minutes=30)
-        diff_name = "Heroic" if difficulty == "raid-heroic" else "Mythic"
-        label     = f"{diff_name}{' – ' + build_label if build_label else ''}"
-        return {"label": label, "url": REPORT_URL.format(sim_id=sim_id), "ok": ok}
+        r = run_raidbots_sim(s, identity, target, character, static,
+                             report_url_template=REPORT_URL)
+        return {"label": label, "url": r.url, "ok": r.ok}
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=len(jobs)) as pool:
         futures = [pool.submit(_one, *j) for j in jobs]

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -8,14 +8,14 @@ from pathlib import Path
 
 import discord
 from discord import app_commands
-import requests as req_lib
 
 from droptimizer import (
-    RAIDBOTS_BASE, RAIDBOTS_HEADERS,
+    RAIDBOTS_BASE,
     apply_talent, build_payload, find_talent_builds,
     fetch_character, fetch_encounter_items,
     get_site_versions, poll_job, submit_job,
 )
+from raidbots_session import make_raidbots_session
 from qe_sim import is_healer, run_qe_upgradefinder
 
 CONFIG_PATH = Path(__file__).parent / "config.json"
@@ -77,13 +77,6 @@ def _parse_simc(simc: str) -> dict:
     return result
 
 
-def _make_session(raidsid: str) -> req_lib.Session:
-    s = req_lib.Session()
-    s.headers.update(RAIDBOTS_HEADERS)
-    if raidsid:
-        s.cookies.set("raidsid", raidsid, domain="www.raidbots.com")
-    return s
-
 
 def _run_sims(simc: str, raidsid: str) -> list[dict]:
     """
@@ -126,7 +119,7 @@ def _run_sims(simc: str, raidsid: str) -> list[dict]:
         return results
 
     # ── DPS / Tank: use Raidbots Droptimizer ────────────────────────────────
-    init_session = _make_session(raidsid)
+    init_session = make_raidbots_session(raidsid)
     static_hash, frontend_version = get_site_versions(init_session)
     encounter_items = fetch_encounter_items(init_session, static_hash)
     instances = init_session.get(
@@ -143,7 +136,7 @@ def _run_sims(simc: str, raidsid: str) -> list[dict]:
     ]
 
     def _one(build_label: str, talent_code: str | None, difficulty: str) -> dict:
-        s = _make_session(raidsid)
+        s = make_raidbots_session(raidsid)
         sim_simc = apply_talent(simc_final, talent_code) if talent_code else simc_final
         cfg_wrap = {
             "character":   {"name": info["name"], "realm": info["realm"], "region": info["region"]},

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -11,10 +11,10 @@ from discord import app_commands
 
 from droptimizer import (
     RAIDBOTS_BASE,
-    apply_talent, build_payload, find_talent_builds,
-    fetch_character, fetch_encounter_items,
-    get_site_versions, poll_job, submit_job,
+    apply_talent, fetch_character, fetch_static_data,
+    find_talent_builds, poll_job, submit_job,
 )
+from payload_builder import CharacterIdentity, SimTarget, build_payload
 from raidbots_session import make_raidbots_session
 from qe_sim import is_healer, run_qe_upgradefinder
 
@@ -120,11 +120,7 @@ def _run_sims(simc: str, raidsid: str) -> list[dict]:
 
     # ── DPS / Tank: use Raidbots Droptimizer ────────────────────────────────
     init_session = make_raidbots_session(raidsid)
-    static_hash, frontend_version = get_site_versions(init_session)
-    encounter_items = fetch_encounter_items(init_session, static_hash)
-    instances = init_session.get(
-        f"{RAIDBOTS_BASE}/static/data/{static_hash}/instances.json", timeout=15
-    ).json()
+    static    = fetch_static_data(init_session)
     character = fetch_character(init_session, info["region"], info["realm"], info["name"])
 
     # Build job list
@@ -138,21 +134,17 @@ def _run_sims(simc: str, raidsid: str) -> list[dict]:
     def _one(build_label: str, talent_code: str | None, difficulty: str) -> dict:
         s = make_raidbots_session(raidsid)
         sim_simc = apply_talent(simc_final, talent_code) if talent_code else simc_final
-        cfg_wrap = {
-            "character":   {"name": info["name"], "realm": info["realm"], "region": info["region"]},
-            "simc_string": sim_simc,
-        }
-        run_opts = {
-            "difficulty":    difficulty,
-            "instance_id":   -91,
-            "spec":          info["spec"].capitalize(),
-            "spec_id":       spec_id,
-            "loot_spec_id":  loot_spec_id,
-            "fight_style":   "Patchwerk",
-            "iterations":    "smart",
-            "crafted_stats": crafted_stats,
-        }
-        payload   = build_payload(cfg_wrap, run_opts, character, encounter_items, instances, frontend_version)
+        identity = CharacterIdentity(
+            name=info["name"], realm=info["realm"], region=info["region"],
+            spec_label=info["spec"].capitalize(), simc_string=sim_simc,
+        )
+        target = SimTarget(
+            difficulty=difficulty,
+            spec_id=spec_id,
+            loot_spec_id=loot_spec_id,
+            crafted_stats=crafted_stats,
+        )
+        payload   = build_payload(identity, target, character, static)
         sim_id, _ = submit_job(s, payload, None)
         ok        = poll_job(s, sim_id, timeout_minutes=30)
         diff_name = "Heroic" if difficulty == "raid-heroic" else "Mythic"

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -1,0 +1,260 @@
+"""discord_bot.py — Discord bot with /droptimizer slash command."""
+
+import asyncio
+import json
+import re
+import concurrent.futures
+from pathlib import Path
+
+import discord
+from discord import app_commands
+import requests as req_lib
+
+from droptimizer import (
+    RAIDBOTS_BASE, RAIDBOTS_HEADERS,
+    apply_talent, build_payload, find_talent_builds,
+    fetch_character, fetch_encounter_items,
+    get_site_versions, poll_job, submit_job,
+)
+from qe_sim import is_healer, run_qe_upgradefinder
+
+CONFIG_PATH = Path(__file__).parent / "config.json"
+CHARS_PATH  = Path(__file__).parent / "characters.json"
+REPORT_URL  = RAIDBOTS_BASE + "/simbot/report/{sim_id}"
+
+SPEC_IDS: dict[str, dict[str, int]] = {
+    "death_knight": {"blood": 250, "frost": 251, "unholy": 252},
+    "demon_hunter": {"havoc": 577, "vengeance": 581, "devourer": 1480},
+    "druid":        {"balance": 102, "feral": 103, "guardian": 104, "restoration": 105},
+    "evoker":       {"devastation": 1467, "preservation": 1468, "augmentation": 1473},
+    "hunter":       {"beast_mastery": 253, "marksmanship": 254, "survival": 255},
+    "mage":         {"arcane": 62, "fire": 63, "frost": 64},
+    "monk":         {"brewmaster": 268, "mistweaver": 270, "windwalker": 269},
+    "paladin":      {"holy": 65, "protection": 66, "retribution": 70},
+    "priest":       {"discipline": 256, "holy": 257, "shadow": 258},
+    "rogue":        {"assassination": 259, "outlaw": 260, "subtlety": 261},
+    "shaman":       {"elemental": 262, "enhancement": 263, "restoration": 264},
+    "warlock":      {"affliction": 265, "demonology": 266, "destruction": 267},
+    "warrior":      {"arms": 71, "fury": 72, "protection": 73},
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _load_config() -> dict:
+    try:
+        return json.loads(CONFIG_PATH.read_text())
+    except Exception:
+        return {}
+
+
+def _load_characters() -> list:
+    if CHARS_PATH.exists():
+        try:
+            return json.loads(CHARS_PATH.read_text())
+        except Exception:
+            pass
+    return []
+
+
+def _parse_simc(simc: str) -> dict:
+    """Extract name, char_class, region, realm, spec from a SimC string."""
+    result: dict = {}
+    for line in simc.splitlines():
+        m = re.match(r'^([\w][\w\s]*)="([^"]+)"', line)
+        if m and "char_class" not in result:
+            result["char_class"] = m.group(1).strip().lower().replace(" ", "_")
+            result["name"] = m.group(2).strip()
+        kv = re.match(r'^(\w+)\s*=\s*(.+)', line)
+        if not kv:
+            continue
+        k, v = kv.group(1), kv.group(2).strip()
+        if k == "region": result["region"] = v.lower()
+        if k == "server": result["realm"]  = v.lower()
+        if k == "spec":   result["spec"]   = v.lower()
+    return result
+
+
+def _make_session(raidsid: str) -> req_lib.Session:
+    s = req_lib.Session()
+    s.headers.update(RAIDBOTS_HEADERS)
+    if raidsid:
+        s.cookies.set("raidsid", raidsid, domain="www.raidbots.com")
+    return s
+
+
+def _run_sims(simc: str, raidsid: str) -> list[dict]:
+    """
+    Fetch static data, resolve character presets, then run all talent build ×
+    difficulty combinations in parallel.  Returns a list of result dicts.
+    """
+    info = _parse_simc(simc)
+    if not all(k in info for k in ("name", "region", "realm", "spec")):
+        raise ValueError("Could not parse name / region / realm / spec from SimC string.")
+
+    # Resolve presets from saved characters (same name + spec)
+    saved = {
+        (c["name"].lower(), c["spec"].lower()): c
+        for c in _load_characters()
+    }
+    preset = saved.get((info["name"].lower(), info["spec"].lower()))
+    spec_id       = (preset.get("spec_id")      if preset else None) or \
+                    SPEC_IDS.get(info.get("char_class", ""), {}).get(info["spec"], 63)
+    loot_spec_id  = (preset.get("loot_spec_id") if preset else None) or spec_id
+    crafted_stats = (preset.get("crafted_stats") if preset else None) or "36/49"
+    simc_final    = (preset.get("simc_string")   if preset else None) or simc
+
+    # ── Healer: use QE Upgrade Finder ───────────────────────────────────────
+    if is_healer(spec_id):
+        talent_builds = find_talent_builds(simc_final) or {"": None}
+        results = []
+
+        def _qe_one(build_label: str, talent_code: str | None) -> dict:
+            sim_simc = apply_talent(simc_final, talent_code) if talent_code else simc_final
+            label = f"Heroic + Mythic{' – ' + build_label if build_label else ''}"
+            try:
+                url = run_qe_upgradefinder(sim_simc)
+                return {"label": label, "url": url, "ok": True}
+            except Exception as e:
+                return {"label": label, "url": "", "ok": False, "error": str(e)}
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=len(talent_builds)) as pool:
+            futures = [pool.submit(_qe_one, bl, tc) for bl, tc in talent_builds.items()]
+            results = [f.result() for f in concurrent.futures.as_completed(futures)]
+        return results
+
+    # ── DPS / Tank: use Raidbots Droptimizer ────────────────────────────────
+    init_session = _make_session(raidsid)
+    static_hash, frontend_version = get_site_versions(init_session)
+    encounter_items = fetch_encounter_items(init_session, static_hash)
+    instances = init_session.get(
+        f"{RAIDBOTS_BASE}/static/data/{static_hash}/instances.json", timeout=15
+    ).json()
+    character = fetch_character(init_session, info["region"], info["realm"], info["name"])
+
+    # Build job list
+    talent_builds = find_talent_builds(simc_final) or {"": None}
+    jobs = [
+        (build_label, talent_code, difficulty)
+        for build_label, talent_code in talent_builds.items()
+        for difficulty in ("raid-heroic", "raid-mythic")
+    ]
+
+    def _one(build_label: str, talent_code: str | None, difficulty: str) -> dict:
+        s = _make_session(raidsid)
+        sim_simc = apply_talent(simc_final, talent_code) if talent_code else simc_final
+        cfg_wrap = {
+            "character":   {"name": info["name"], "realm": info["realm"], "region": info["region"]},
+            "simc_string": sim_simc,
+        }
+        run_opts = {
+            "difficulty":    difficulty,
+            "instance_id":   -91,
+            "spec":          info["spec"].capitalize(),
+            "spec_id":       spec_id,
+            "loot_spec_id":  loot_spec_id,
+            "fight_style":   "Patchwerk",
+            "iterations":    "smart",
+            "crafted_stats": crafted_stats,
+        }
+        payload   = build_payload(cfg_wrap, run_opts, character, encounter_items, instances, frontend_version)
+        sim_id, _ = submit_job(s, payload, None)
+        ok        = poll_job(s, sim_id, timeout_minutes=30)
+        diff_name = "Heroic" if difficulty == "raid-heroic" else "Mythic"
+        label     = f"{diff_name}{' – ' + build_label if build_label else ''}"
+        return {"label": label, "url": REPORT_URL.format(sim_id=sim_id), "ok": ok}
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(jobs)) as pool:
+        futures = [pool.submit(_one, *j) for j in jobs]
+        results = [f.result() for f in concurrent.futures.as_completed(futures)]
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Bot setup
+# ---------------------------------------------------------------------------
+
+intents = discord.Intents.default()
+bot     = discord.Client(intents=intents)
+tree    = app_commands.CommandTree(bot)
+
+
+@bot.event
+async def on_ready():
+    await tree.sync()
+    print(f"[discord] Logged in as {bot.user} — slash commands synced.")
+
+
+@tree.command(name="droptimizer", description="Run Heroic + Mythic droptimizer sims from a SimC string or file")
+@app_commands.describe(
+    simc_string="Paste your SimC string directly here",
+    simc_file="Or attach a .txt SimC export file",
+)
+async def droptimizer_cmd(
+    interaction: discord.Interaction,
+    simc_string: str | None = None,
+    simc_file: discord.Attachment | None = None,
+):
+    if not simc_string and not simc_file:
+        await interaction.response.send_message(
+            "Please provide a SimC string or attach a `.txt` file.", ephemeral=True
+        )
+        return
+
+    await interaction.response.defer(thinking=True, ephemeral=True)
+
+    try:
+        if simc_file:
+            raw  = await simc_file.read()
+            simc = raw.decode("utf-8")
+        else:
+            simc = simc_string
+        info  = _parse_simc(simc)
+        char_label = f"{info.get('name', '?')} – {info.get('spec', '?').capitalize()}"
+    except Exception as e:
+        await interaction.followup.send(f"Could not read SimC input: {e}", ephemeral=True)
+        return
+
+    await interaction.followup.send(
+        f"Running sims for **{char_label}**… I'll DM you the results when done.",
+        ephemeral=True,
+    )
+
+    cfg     = _load_config()
+    raidsid = cfg.get("raidsid", "")
+
+    loop = asyncio.get_running_loop()
+    try:
+        results = await loop.run_in_executor(None, _run_sims, simc, raidsid)
+    except Exception as e:
+        try:
+            await interaction.user.send(f"Droptimizer failed for **{char_label}**: {e}")
+        except discord.Forbidden:
+            pass
+        return
+
+    lines = [f"**Droptimizer results — {char_label}**\n"]
+    for r in sorted(results, key=lambda x: x["label"]):
+        status = "✅" if r["ok"] else "❌"
+        lines.append(f"{status} **{r['label']}** — {r['url']}")
+
+    message = "\n".join(lines)
+    try:
+        await interaction.user.send(message)
+    except discord.Forbidden:
+        await interaction.followup.send(
+            "Couldn't DM you — please enable DMs from server members.\n\n" + message,
+            ephemeral=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Entry point (called from app.py in a thread)
+# ---------------------------------------------------------------------------
+
+def start(token: str) -> None:
+    """Run the bot in a dedicated asyncio event loop (blocking)."""
+    asyncio.run(bot.start(token))

--- a/droptimizer.py
+++ b/droptimizer.py
@@ -134,19 +134,10 @@ RAIDBOTS_HEADERS = {
     "Origin":       "https://www.raidbots.com",
 }
 
-# Difficulty string -> (upgradeLevel bonus ID for 6/6, levelSelectorSequence)
-# Hero track  = raid-heroic, group 611, 6/6 bonusId 12798
-# Myth track  = raid-mythic, group 612, 6/6 bonusId 12806
-DIFFICULTY_MAP = {
-    "raid-heroic": {"upgradeLevel": 12798, "levelSelectorSequence": 611, "itemLevel": "Hero",  "season": "mid1"},
-    "raid-mythic":  {"upgradeLevel": 12806, "levelSelectorSequence": 612, "itemLevel": "Myth",  "season": "mid1"},
-}
-
-# Virtual instance ID -> real raid instance IDs it aggregates.
-# -91 = TWW Season 1 Raids (all three raid instances combined).
-VIRTUAL_INSTANCES: dict[int, list[int]] = {
-    -91: [1307, 1308, 1314],
-}
+from payload_builder import (
+    CharacterIdentity, SimTarget, StaticData,
+    build_payload, DIFFICULTY_MAP, VIRTUAL_INSTANCES,
+)
 
 # ---------------------------------------------------------------------------
 # Discord bot API
@@ -204,330 +195,23 @@ def fetch_encounter_items(session: requests.Session, static_hash: str) -> list:
     return resp.json()
 
 
-def get_slot_name(inventory_type: int) -> str | None:
-    """Map WoW inventoryType to Raidbots slot name."""
-    return {
-        1: "head", 2: "neck", 3: "shoulder", 4: "shirt", 5: "chest",
-        6: "waist", 7: "legs", 8: "feet", 9: "wrist", 10: "hands",
-        11: "finger1", 12: "trinket1", 13: "trinket1", 14: "back",
-        15: "main_hand", 16: "back", 17: "main_hand", 20: "chest",
-        21: "main_hand", 22: "off_hand", 23: "off_hand", 28: "ranged",
-    }.get(inventory_type)
+def fetch_static_data(session: requests.Session) -> StaticData:
+    """Fetch all Raidbots static data needed by build_payload in one call.
 
-
-def build_droptimizer_items(
-    encounter_items: list,
-    instance_data: dict,
-    difficulty: str,
-    character: dict,
-    upgrade_info: dict,
-    all_instances: list,
-) -> list:
+    Returns a :class:`~payload_builder.StaticData` instance containing
+    encounter items, instances, and frontend version — ready to pass
+    directly to :func:`~payload_builder.build_payload`.
     """
-    Build the droptimizerItems array by filtering encounter items
-    for the given instance and applying upgrade bonus IDs.
-    """
-    upgrade_bonus_id    = upgrade_info["upgradeLevel"]
-    level_selector_seq  = upgrade_info["levelSelectorSequence"]
-    item_level_name     = upgrade_info["itemLevel"]
-    season              = upgrade_info["season"]
-    class_id            = character.get("class", 8)
-
-    # Virtual instances like -91 (Season 1 Raids) aggregate encounters from
-    # multiple real raid instances. If the virtual instance has no direct
-    # encounters, expand it using the VIRTUAL_INSTANCES mapping.
-    virtual_instance_id = instance_data["id"]
-    enc_list = instance_data.get("encounters", [])
-    if not enc_list and virtual_instance_id in VIRTUAL_INSTANCES:
-        sub_ids = set(VIRTUAL_INSTANCES[virtual_instance_id])
-        enc_list = [
-            enc
-            for inst in all_instances
-            if inst["id"] in sub_ids
-            for enc in inst.get("encounters", [])
-        ]
-    virtual_encounter_ids   = {e["id"] for e in enc_list}
-    virtual_encounter_order = {e["id"]: i for i, e in enumerate(enc_list)}
-
-    # Map encounterId -> real instanceId from non-virtual instances
-    encounter_to_real_instance: dict[int, int] = {}
-    for inst in all_instances:
-        if inst["id"] < 0:
-            continue
-        for enc in inst.get("encounters", []):
-            if enc["id"] in virtual_encounter_ids:
-                encounter_to_real_instance[enc["id"]] = inst["id"]
-
-    log.info(
-        "Resolved %d encounters across real instances: %s",
-        len(encounter_to_real_instance),
-        sorted(set(encounter_to_real_instance.values())),
+    static_hash, frontend_version = get_site_versions(session)
+    encounter_items = fetch_encounter_items(session, static_hash)
+    instances = session.get(
+        f"{RAIDBOTS_BASE}/static/data/{static_hash}/instances.json", timeout=15
+    ).json()
+    return StaticData(
+        encounter_items=encounter_items,
+        instances=instances,
+        frontend_version=frontend_version,
     )
-
-    result = []
-
-    for item in encounter_items:
-        sources = item.get("sources", [])
-        item_class = item.get("itemClass")
-        inv_type   = item.get("inventoryType")
-
-        # Skip non-gear
-        if item_class not in (2, 4):
-            continue
-        slot = get_slot_name(inv_type)
-        if not slot:
-            continue
-
-        # Check if item comes from any encounter in this virtual instance
-        matching_sources = [
-            s for s in sources
-            if s.get("encounterId") in virtual_encounter_ids
-        ]
-        if not matching_sources:
-            continue
-
-        # Check class restrictions
-        allowed_classes = item.get("allowableClasses")
-        if allowed_classes and class_id not in allowed_classes:
-            continue
-
-        # Emit one entry per source encounter
-        seen = set()
-        for src in matching_sources:
-            enc_id = src["encounterId"]
-            key = (item["id"], enc_id, slot)
-            if key in seen:
-                continue
-            seen.add(key)
-
-            seq_offset  = virtual_encounter_order.get(enc_id, 0)
-            real_inst_id = encounter_to_real_instance.get(enc_id, virtual_instance_id)
-
-            # Apply upgrade bonus IDs: [quality_bonus, expansion_bonus, upgrade_level_bonus]
-            bonus_lists = [4799, 4786, upgrade_bonus_id]
-            socket_info = item.get("socketInfo", {})
-            has_socket = (
-                isinstance(socket_info, dict) and
-                any(isinstance(v, dict) and v.get("staticSlots", 0) > 0
-                    for v in socket_info.values())
-            )
-            if has_socket:
-                bonus_lists = [13668] + bonus_lists
-
-            enchant_id = 0
-            # Carry forward the player's current enchant if same slot
-            equipped = character.get("items", {})
-            for eq_slot, eq_item in equipped.items():
-                if not isinstance(eq_item, dict):
-                    continue
-                if get_slot_name(eq_item.get("inventoryType", 0)) == slot:
-                    enchant_id = eq_item.get("enchant_id") or 0
-                    break
-
-            # Find the real instance and encounter objects for embedding
-            real_instance_obj = next(
-                (i for i in all_instances if i["id"] == real_inst_id), {"id": real_inst_id}
-            )
-            encounter_obj = next(
-                (e for i in all_instances if i["id"] == real_inst_id
-                 for e in i.get("encounters", []) if e["id"] == enc_id),
-                {"id": enc_id}
-            )
-
-            entry = {
-                "id": f"{real_inst_id}/{enc_id}/{difficulty}/{item['id']}/{item.get('itemLevel', 276)}/{enchant_id}/{slot}///",
-                "slot": slot,
-                "item": {
-                    **{k: v for k, v in item.items() if k not in ("sources",)},
-                    "bonusLists":   bonus_lists,
-                    "bonus_id":     "/".join(str(b) for b in bonus_lists),
-                    "enchant_id":   enchant_id,
-                    "gem_id":       "",
-                    "instanceId":   real_inst_id,
-                    "encounterId":  enc_id,
-                    "difficulty":   difficulty,
-                    "offSpecItem":  False,
-                    "upgrade": {
-                        "group":    level_selector_seq,
-                        "level":    6,
-                        "max":      6,
-                        "name":     item_level_name,
-                        "fullName": f"{item_level_name} 6/6",
-                        "bonusId":  upgrade_bonus_id,
-                        "itemLevel": item.get("itemLevel", 276),
-                        "seasonId": 34,
-                    },
-                    "instance": real_instance_obj,
-                    "encounter": encounter_obj,
-                    "overrides": {
-                        "encounterId":               enc_id,
-                        "encounterSequenceOffset":   seq_offset,
-                        "instanceId":                real_inst_id,
-                        "difficulty":                difficulty,
-                        "itemLevel":                 item_level_name,
-                        "levelSelectorSequence":     level_selector_seq,
-                        "season":                    season,
-                        "levelSelectorSetUpgradeTrack": True,
-                        "seasonId":                  34,
-                        "disableWarforgeLevel":      True,
-                        "enableSockets":             True,
-                        "itemConversion":            {"id": 12, "minLevel": 220},
-                        "instance":                  real_instance_obj,
-                        "encounter":                 encounter_obj,
-                        "encounterType":             "boss",
-                        "encounterTypePlural":       "bosses",
-                        "quality":                   4,
-                    },
-                    "socketInfo": item.get("socketInfo", {}),
-                    "tooltipParams": {"enchant": enchant_id},
-                },
-            }
-            result.append(entry)
-
-    log.info("Built %d droptimizerItems for instance %s %s", len(result), virtual_instance_id, difficulty)
-    return result
-
-
-def build_payload(
-    cfg: dict,
-    run: dict,
-    character: dict,
-    encounter_items: list,
-    instances: list,
-    frontend_version: str = "76b791ae3944c21fb3d4",
-) -> dict:
-    char    = cfg["character"]
-    diff_key = run.get("difficulty", "raid-heroic")  # e.g. "raid-heroic"
-    instance_numeric = run.get("instance_id", -91)
-
-    upgrade_info = DIFFICULTY_MAP.get(diff_key, DIFFICULTY_MAP["raid-heroic"])
-
-    # Find the instance data
-    instance_data = next(
-        (i for i in instances if i["id"] == instance_numeric), {}
-    )
-
-    droptimizer_items = build_droptimizer_items(
-        encounter_items, instance_data, diff_key, character, upgrade_info, instances
-    )
-
-    spec_id      = run.get("spec_id", 63)
-    loot_spec_id = run.get("loot_spec_id", spec_id)
-    class_id     = character.get("class", 8)
-    faction      = "alliance" if character.get("faction", 0) == 0 else "horde"
-
-    # Strip None and non-dict entries from items objects — Raidbots backend
-    # crashes (500) when it encounters nil slots like offHand/shirt/tabard.
-    clean_items = {k: v for k, v in character.get("items", {}).items() if isinstance(v, dict)}
-    character = {**character, "items": clean_items}
-
-    report_name = (
-        f"Droptimizer • Season 1 Raids • "
-        f"{'Heroic' if diff_key == 'raid-heroic' else 'Mythic'} • "
-        f"{upgrade_info['itemLevel']} 6/6"
-    )
-
-    payload = {
-        "type":             "droptimizer",
-        "text":             cfg.get("simc_string", ""),
-        "baseActorName":    char["name"],
-        "spec":             run.get("spec", "Fire"),
-        "armory":           {"region": char["region"], "realm": char["realm"], "name": char["name"]},
-        "character":        character,
-        "reportName":       report_name,
-        "frontendHost":     "www.raidbots.com",
-        "frontendVersion":  frontend_version,
-        "iterations":       run.get("iterations", "smart"),
-        "fightStyle":       run.get("fight_style", "Patchwerk"),
-        "fightLength":      300,
-        "enemyCount":       1,
-        "enemyType":        "FluffyPillow",
-        "bloodlust":        True,
-        "arcaneIntellect":  True,
-        "fortitude":        True,
-        "battleShout":      True,
-        "mysticTouch":      True,
-        "chaosBrand":       True,
-        "markOfTheWild":    True,
-        "skyfury":          True,
-        "bleeding":         True,
-        "reportDetails":    True,
-        "ptr":              False,
-        "simcVersion":      "weekly",
-        # Legacy/optional sim toggles — required by Raidbots backend
-        "aberration":                   False,
-        "apl":                          "",
-        "astralAntennaMissChance":      10,
-        "attunedToTheAether":           False,
-        "augmentation":                 "",
-        "balefireBranchRngType":        "constant",
-        "blueSilkenLining":             40,
-        "cabalistsHymnalInParty":       0,
-        "corruptingRageUptime":         80,
-        "covenantChance":               100,
-        "cruciblePredation":            True,
-        "crucibleSustenance":           True,
-        "crucibleViolence":             True,
-        "dawnDuskThreadLining":         100,
-        "disableIqdExecute":            False,
-        "email":                        "",
-        "enableDominationShards":       False,
-        "enableRuneWords":              False,
-        "essenceGorgerHighStat":        False,
-        "flask":                        "",
-        "food":                         "",
-        "frontendVersion":              "aa117406d3c58c9dc83a0df039513166f66a640a",
-        "gearsets":                     [],
-        "huntersMark":                  True,
-        "iqdStatFailChance":            0,
-        "loyalToTheEndAllies":          0,
-        "nazjatar":                     False,
-        "nyalotha":                     True,
-        "ocularGlandUptime":            100,
-        "ominousChromaticEssenceAllies":   "",
-        "ominousChromaticEssencePersonal": "obsidian",
-        "potion":                       "",
-        "powerInfusion":                False,
-        "primalRitualShell":            "wind",
-        "rubyWhelpShellTraining":       "",
-        "sendEmail":                    False,
-        "smartAggressive":              False,
-        "smartHighPrecision":           True,
-        "soleahStatType":               "haste",
-        "stoneLegionHeraldryInParty":   0,
-        "surgingVitality":              0,
-        "symbioticPresence":            22,
-        "talentSets":                   [],
-        "talents":                      None,
-        "temporaryEnchant":             "",
-        "unboundChangelingStatType":    "",
-        "undulatingTides":              100,
-        "voidRitual":                   False,
-        "whisperingIncarnateIconRoles": "dps/heal/tank",
-        "worldveinAllies":              0,
-        "droptimizer": {
-            "equipped":             character.get("items", {}),
-            "instance":             instance_numeric,
-            "difficulty":           diff_key,
-            "warforgeLevel":        0,
-            "upgradeLevel":         upgrade_info["upgradeLevel"],
-            "upgradeEquipped":      False,
-            "gem":                  None,
-            "classId":              class_id,
-            "specId":               spec_id,
-            "lootSpecId":           loot_spec_id,
-            "faction":              faction,
-            "craftedStats":         run.get("crafted_stats", "36/49"),
-            "offSpecItems":         False,
-            "includeConversions":   True,
-        },
-        "droptimizerItems": droptimizer_items,
-        "simOptions": {
-            "fightstyle": run.get("fight_style", "Patchwerk"),
-            "iterations": run.get("iterations", "smart"),
-        },
-    }
-    return payload
 
 
 def submit_job(session: requests.Session, payload: dict, api_key: str | None) -> tuple[str, str]:
@@ -694,25 +378,30 @@ def main() -> None:
         log.error("No 'runs' defined in config.json")
         sys.exit(1)
 
-    # Build a shared session with cookies
     from raidbots_session import make_raidbots_session
-    session = make_raidbots_session(raidsid)
-
-    # Fetch static data once
-    static_hash, frontend_version = get_site_versions(session)
-    log.info("Using static data hash: %s  frontend: %s", static_hash, frontend_version)
-    character       = fetch_character(session, char_cfg["region"], char_cfg["realm"], char_cfg["name"])
-    encounter_items = fetch_encounter_items(session, static_hash)
-
-    # Fetch instances list
-    instances_resp = session.get(
-        f"{RAIDBOTS_BASE}/static/data/{static_hash}/instances.json", timeout=15
-    )
-    instances = instances_resp.json()
+    session   = make_raidbots_session(raidsid)
+    static    = fetch_static_data(session)
+    character = fetch_character(session, char_cfg["region"], char_cfg["realm"], char_cfg["name"])
 
     results = []
     for run in runs:
-        payload         = build_payload(cfg, run, character, encounter_items, instances, frontend_version)
+        identity = CharacterIdentity(
+            name=char_cfg["name"],
+            realm=char_cfg["realm"],
+            region=char_cfg["region"],
+            spec_label=run.get("spec", "Fire"),
+            simc_string=simc,
+        )
+        target = SimTarget(
+            difficulty=run.get("difficulty", "raid-heroic"),
+            instance_id=run.get("instance_id", -91),
+            spec_id=run.get("spec_id", 63),
+            loot_spec_id=run.get("loot_spec_id", run.get("spec_id", 63)),
+            fight_style=run.get("fight_style", "Patchwerk"),
+            iterations=run.get("iterations", "smart"),
+            crafted_stats=run.get("crafted_stats", "36/49"),
+        )
+        payload         = build_payload(identity, target, character, static)
         job_id, sim_id  = submit_job(session, payload, api_key)
         success         = poll_job(session, job_id, timeout_minutes=timeout)
 

--- a/droptimizer.py
+++ b/droptimizer.py
@@ -695,10 +695,8 @@ def main() -> None:
         sys.exit(1)
 
     # Build a shared session with cookies
-    session = requests.Session()
-    session.headers.update(RAIDBOTS_HEADERS)
-    if raidsid:
-        session.cookies.set("raidsid", raidsid, domain="www.raidbots.com")
+    from raidbots_session import make_raidbots_session
+    session = make_raidbots_session(raidsid)
 
     # Fetch static data once
     static_hash, frontend_version = get_site_versions(session)

--- a/job_state.py
+++ b/job_state.py
@@ -1,0 +1,299 @@
+"""job_state.py — Typed job state machine with enforced transition DAG.
+
+All mutable run state lives here.  ``app.py`` creates a single module-level
+:class:`SimRunnerState` instance; route handlers and the background worker
+interact with it through the public API rather than mutating a raw dict.
+
+Design goals
+------------
+- One :class:`threading.RLock` owned by ``SimRunnerState`` — never exposed.
+- Transition DAG enforced: invalid transitions raise :exc:`InvalidTransitionError`.
+- Observers notified after each transition (used for e.g. Discord push).
+- ``snapshot()`` returns a deep copy so callers cannot mutate live state.
+- ``persist_path`` injected at construction — pass ``Path("/dev/null")`` in tests.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+import threading
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Callable, Optional
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Status enum and transition graph
+# ---------------------------------------------------------------------------
+
+class JobStatus(str, Enum):
+    PENDING    = "pending"
+    FETCHING   = "fetching"
+    SUBMITTING = "submitting"
+    RUNNING    = "running"
+    DONE       = "done"
+    FAILED     = "failed"
+    CANCELLED  = "cancelled"
+    SKIPPED    = "skipped"   # healer mythic twin — silently collapsed into heroic job
+
+
+# Allowed transitions.  Terminal statuses (DONE/FAILED/CANCELLED/SKIPPED) have
+# no outgoing edges and will raise InvalidTransitionError if transitioned from.
+_TRANSITIONS: dict[JobStatus, frozenset[JobStatus]] = {
+    JobStatus.PENDING:    frozenset({
+        JobStatus.FETCHING,
+        JobStatus.SUBMITTING,   # healer path skips FETCHING
+        JobStatus.RUNNING,      # healer path skips directly to RUNNING
+        JobStatus.SKIPPED,
+        JobStatus.FAILED,
+        JobStatus.CANCELLED,
+    }),
+    JobStatus.FETCHING:   frozenset({
+        JobStatus.SUBMITTING,
+        JobStatus.FAILED,
+        JobStatus.CANCELLED,
+    }),
+    JobStatus.SUBMITTING: frozenset({
+        JobStatus.RUNNING,
+        JobStatus.FAILED,
+        JobStatus.CANCELLED,
+    }),
+    JobStatus.RUNNING:    frozenset({
+        JobStatus.DONE,
+        JobStatus.FAILED,
+        JobStatus.CANCELLED,
+    }),
+}
+
+
+class InvalidTransitionError(ValueError):
+    """Raised when a requested status transition is not in the allowed DAG."""
+
+
+# ---------------------------------------------------------------------------
+# Job dataclass
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Job:
+    """A single simulation job (one character × one difficulty × one talent build)."""
+    id:           str
+    char_id:      str
+    label:        str
+    difficulty:   str
+    talent_code:  Optional[str] = None
+    status:       JobStatus     = JobStatus.PENDING
+    sim_id:       Optional[str] = None
+    url:          Optional[str] = None
+
+    def as_dict(self) -> dict:
+        return {
+            "id":          self.id,
+            "char_id":     self.char_id,
+            "label":       self.label,
+            "difficulty":  self.difficulty,
+            "talent_code": self.talent_code,
+            "status":      self.status.value,
+            "sim_id":      self.sim_id,
+            "url":         self.url,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "Job":
+        return cls(
+            id=d["id"],
+            char_id=d["char_id"],
+            label=d["label"],
+            difficulty=d["difficulty"],
+            talent_code=d.get("talent_code"),
+            status=JobStatus(d.get("status", "pending")),
+            sim_id=d.get("sim_id"),
+            url=d.get("url"),
+        )
+
+
+# Observer type: called with (job_after_transition, old_status)
+JobObserver = Callable[[Job, JobStatus], None]
+
+
+# ---------------------------------------------------------------------------
+# SimRunnerState
+# ---------------------------------------------------------------------------
+
+class SimRunnerState:
+    """Thread-safe run state container with enforced transition DAG.
+
+    Args:
+        persist_path: Path to write/read ``last_run.json``.  Pass
+                      ``Path("/dev/null")`` or ``Path("nul")`` in tests to
+                      suppress all file I/O.
+    """
+
+    def __init__(self, persist_path: Path) -> None:
+        self._persist_path = persist_path
+        self._lock         = threading.RLock()
+        self._running      = False
+        self._jobs:  list[Job] = []
+        self._log:   list[str] = []
+        self._observers: list[JobObserver] = []
+        self._load()
+
+    # ------------------------------------------------------------------
+    # Observer API
+    # ------------------------------------------------------------------
+
+    def add_observer(self, observer: JobObserver) -> None:
+        """Register a callback invoked after every job transition."""
+        with self._lock:
+            self._observers.append(observer)
+
+    def _notify(self, job: Job, old_status: JobStatus) -> None:
+        for obs in self._observers:
+            try:
+                obs(job, old_status)
+            except Exception as exc:
+                log.warning("Observer %r raised: %s", obs, exc)
+
+    # ------------------------------------------------------------------
+    # Run lifecycle
+    # ------------------------------------------------------------------
+
+    def start_run(self, jobs: list[Job]) -> None:
+        """Begin a new run.  Raises :exc:`RuntimeError` if already running."""
+        with self._lock:
+            if self._running:
+                raise RuntimeError("A run is already in progress.")
+            self._running = True
+            self._jobs = list(jobs)
+            self._log  = []
+
+    def finish_run(self) -> None:
+        """Mark the run as finished and persist state to disk."""
+        with self._lock:
+            self._running = False
+            snapshot = self._snapshot_unsafe()
+        self._persist(snapshot)
+
+    # ------------------------------------------------------------------
+    # State mutations
+    # ------------------------------------------------------------------
+
+    def transition(
+        self,
+        job_id:     str,
+        new_status: JobStatus,
+        *,
+        sim_id: Optional[str] = None,
+        url:    Optional[str] = None,
+        label:  Optional[str] = None,
+    ) -> Job:
+        """Transition *job_id* to *new_status*.
+
+        Raises :exc:`InvalidTransitionError` if the transition is not allowed.
+        Raises :exc:`KeyError` if *job_id* is not found.
+        Fires all registered observers after the transition.
+        """
+        with self._lock:
+            job = self._get_job(job_id)
+            old_status = job.status
+            allowed = _TRANSITIONS.get(old_status, frozenset())
+            if new_status not in allowed:
+                raise InvalidTransitionError(
+                    f"Cannot transition job {job_id!r} from {old_status!r} to {new_status!r}. "
+                    f"Allowed: {sorted(s.value for s in allowed)}"
+                )
+            job.status = new_status
+            if sim_id is not None:
+                job.sim_id = sim_id
+            if url is not None:
+                job.url = url
+            if label is not None:
+                job.label = label
+            job_copy = copy.copy(job)
+
+        self._notify(job_copy, old_status)
+        return job_copy
+
+    def cancel(self, job_id: str) -> Job:
+        """Cancel a single non-terminal job."""
+        with self._lock:
+            job = self._get_job(job_id)
+            if job.status in _TRANSITIONS:   # non-terminal
+                return self.transition(job_id, JobStatus.CANCELLED)
+            return copy.copy(job)
+
+    def cancel_all(self) -> list[str]:
+        """Cancel all non-terminal jobs.  Returns list of cancelled job IDs."""
+        cancelled = []
+        with self._lock:
+            ids = [j.id for j in self._jobs if j.status in _TRANSITIONS]
+        for jid in ids:
+            try:
+                self.cancel(jid)
+                cancelled.append(jid)
+            except Exception:
+                pass
+        return cancelled
+
+    def append_log(self, msg: str) -> None:
+        """Append *msg* to the run log."""
+        with self._lock:
+            self._log.append(msg)
+
+    # ------------------------------------------------------------------
+    # Read-only access
+    # ------------------------------------------------------------------
+
+    @property
+    def running(self) -> bool:
+        with self._lock:
+            return self._running
+
+    def snapshot(self) -> dict:
+        """Return a deep copy of current state safe for JSON serialisation."""
+        with self._lock:
+            return self._snapshot_unsafe()
+
+    def get_job(self, job_id: str) -> Job:
+        """Return a copy of the job with *job_id*.  Raises :exc:`KeyError` if not found."""
+        with self._lock:
+            return copy.copy(self._get_job(job_id))
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _get_job(self, job_id: str) -> Job:
+        """Caller must hold _lock."""
+        for j in self._jobs:
+            if j.id == job_id:
+                return j
+        raise KeyError(f"Job {job_id!r} not found.")
+
+    def _snapshot_unsafe(self) -> dict:
+        """Caller must hold _lock."""
+        return {
+            "running": self._running,
+            "jobs":    [j.as_dict() for j in self._jobs],
+            "log":     list(self._log),
+        }
+
+    def _persist(self, snapshot: dict) -> None:
+        try:
+            self._persist_path.write_text(json.dumps(snapshot, indent=2))
+        except Exception as exc:
+            log.warning("Could not persist run state to %s: %s", self._persist_path, exc)
+
+    def _load(self) -> None:
+        """Load last-run state from disk on startup (best-effort)."""
+        try:
+            data = json.loads(self._persist_path.read_text())
+            self._jobs = [Job.from_dict(d) for d in data.get("jobs", [])]
+            self._log  = data.get("log", [])
+        except Exception:
+            pass

--- a/payload_builder.py
+++ b/payload_builder.py
@@ -1,0 +1,439 @@
+"""payload_builder.py — Pure Raidbots Droptimizer payload construction.
+
+All functions here are pure (no network I/O, no file I/O).  The only runtime
+dependency is the standard library plus the dataclasses already on ``sys.path``.
+This makes the module trivially testable with fixture data captured once from
+live Raidbots responses.
+
+Typical usage
+-------------
+::
+
+    from payload_builder import (
+        CharacterIdentity, SimTarget, StaticData, build_payload,
+    )
+    from droptimizer import fetch_static_data
+
+    static   = fetch_static_data(session)
+    identity = CharacterIdentity(
+        name="Xiantus", realm="illidan", region="us",
+        spec_label="Fire", simc_string=simc,
+    )
+    target = SimTarget(
+        difficulty="raid-heroic", instance_id=-91,
+        spec_id=63, loot_spec_id=63,
+    )
+    payload = build_payload(identity, target, character_data, static)
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Static lookup tables (moved from droptimizer.py)
+# ---------------------------------------------------------------------------
+
+# Difficulty string → Raidbots bonus ID / upgrade track metadata.
+# Hero track  = raid-heroic, group 611, 6/6 bonusId 12798
+# Myth track  = raid-mythic, group 612, 6/6 bonusId 12806
+DIFFICULTY_MAP: dict[str, dict[str, Any]] = {
+    "raid-heroic": {
+        "upgradeLevel": 12798,
+        "levelSelectorSequence": 611,
+        "itemLevel": "Hero",
+        "season": "mid1",
+    },
+    "raid-mythic": {
+        "upgradeLevel": 12806,
+        "levelSelectorSequence": 612,
+        "itemLevel": "Myth",
+        "season": "mid1",
+    },
+}
+
+# Virtual instance ID → real raid instance IDs it aggregates.
+# -91 = TWW Season 1 Raids (all three raid instances combined).
+VIRTUAL_INSTANCES: dict[int, list[int]] = {
+    -91: [1307, 1308, 1314],
+}
+
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class CharacterIdentity:
+    """Who is being simulated and which spec string Raidbots expects."""
+    name:        str
+    realm:       str
+    region:      str
+    spec_label:  str   # e.g. "Fire" — used in reportName and payload["spec"]
+    simc_string: str   # full SimC APL text
+
+
+@dataclass(frozen=True)
+class SimTarget:
+    """What simulation to run."""
+    difficulty:    str         # "raid-heroic" | "raid-mythic"
+    instance_id:   int = -91   # -91 = Season 1 virtual instance
+    spec_id:       int = 63
+    loot_spec_id:  int = 63
+    fight_style:   str = "Patchwerk"
+    iterations:    str = "smart"
+    crafted_stats: str = "36/49"
+
+
+@dataclass(frozen=True)
+class StaticData:
+    """Pre-fetched Raidbots static data needed by build_payload."""
+    encounter_items:  list
+    instances:        list
+    frontend_version: str
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers (previously in droptimizer.py)
+# ---------------------------------------------------------------------------
+
+def get_slot_name(inventory_type: int) -> str | None:
+    """Map WoW inventoryType integer to a Raidbots slot name string."""
+    return {
+        1: "head",      2: "neck",      3: "shoulder",  4: "shirt",
+        5: "chest",     6: "waist",     7: "legs",      8: "feet",
+        9: "wrist",     10: "hands",    11: "finger1",  12: "trinket1",
+        13: "trinket1", 14: "back",     15: "main_hand", 16: "back",
+        17: "main_hand", 20: "chest",   21: "main_hand", 22: "off_hand",
+        23: "off_hand", 28: "ranged",
+    }.get(inventory_type)
+
+
+def _build_droptimizer_items(
+    encounter_items: list,
+    instance_data:   dict,
+    difficulty:      str,
+    character:       dict,
+    upgrade_info:    dict,
+    all_instances:   list,
+) -> list:
+    """Build the droptimizerItems array for a single difficulty/instance."""
+    upgrade_bonus_id   = upgrade_info["upgradeLevel"]
+    level_selector_seq = upgrade_info["levelSelectorSequence"]
+    item_level_name    = upgrade_info["itemLevel"]
+    season             = upgrade_info["season"]
+    class_id           = character.get("class", 8)
+
+    virtual_instance_id = instance_data["id"]
+    enc_list = instance_data.get("encounters", [])
+    if not enc_list and virtual_instance_id in VIRTUAL_INSTANCES:
+        sub_ids = set(VIRTUAL_INSTANCES[virtual_instance_id])
+        enc_list = [
+            enc
+            for inst in all_instances
+            if inst["id"] in sub_ids
+            for enc in inst.get("encounters", [])
+        ]
+    virtual_encounter_ids   = {e["id"] for e in enc_list}
+    virtual_encounter_order = {e["id"]: i for i, e in enumerate(enc_list)}
+
+    encounter_to_real_instance: dict[int, int] = {}
+    for inst in all_instances:
+        if inst["id"] < 0:
+            continue
+        for enc in inst.get("encounters", []):
+            if enc["id"] in virtual_encounter_ids:
+                encounter_to_real_instance[enc["id"]] = inst["id"]
+
+    log.info(
+        "Resolved %d encounters across real instances: %s",
+        len(encounter_to_real_instance),
+        sorted(set(encounter_to_real_instance.values())),
+    )
+
+    result = []
+
+    for item in encounter_items:
+        sources   = item.get("sources", [])
+        item_class = item.get("itemClass")
+        inv_type   = item.get("inventoryType")
+
+        if item_class not in (2, 4):
+            continue
+        slot = get_slot_name(inv_type)
+        if not slot:
+            continue
+
+        matching_sources = [
+            s for s in sources
+            if s.get("encounterId") in virtual_encounter_ids
+        ]
+        if not matching_sources:
+            continue
+
+        allowed_classes = item.get("allowableClasses")
+        if allowed_classes and class_id not in allowed_classes:
+            continue
+
+        seen = set()
+        for src in matching_sources:
+            enc_id = src["encounterId"]
+            key = (item["id"], enc_id, slot)
+            if key in seen:
+                continue
+            seen.add(key)
+
+            seq_offset   = virtual_encounter_order.get(enc_id, 0)
+            real_inst_id = encounter_to_real_instance.get(enc_id, virtual_instance_id)
+
+            bonus_lists = [4799, 4786, upgrade_bonus_id]
+            socket_info = item.get("socketInfo", {})
+            has_socket = (
+                isinstance(socket_info, dict) and
+                any(
+                    isinstance(v, dict) and v.get("staticSlots", 0) > 0
+                    for v in socket_info.values()
+                )
+            )
+            if has_socket:
+                bonus_lists = [13668] + bonus_lists
+
+            enchant_id = 0
+            for eq_item in character.get("items", {}).values():
+                if not isinstance(eq_item, dict):
+                    continue
+                if get_slot_name(eq_item.get("inventoryType", 0)) == slot:
+                    enchant_id = eq_item.get("enchant_id") or 0
+                    break
+
+            real_instance_obj = next(
+                (i for i in all_instances if i["id"] == real_inst_id),
+                {"id": real_inst_id},
+            )
+            encounter_obj = next(
+                (
+                    e for i in all_instances if i["id"] == real_inst_id
+                    for e in i.get("encounters", []) if e["id"] == enc_id
+                ),
+                {"id": enc_id},
+            )
+
+            entry = {
+                "id": (
+                    f"{real_inst_id}/{enc_id}/{difficulty}/{item['id']}/"
+                    f"{item.get('itemLevel', 276)}/{enchant_id}/{slot}///"
+                ),
+                "slot": slot,
+                "item": {
+                    **{k: v for k, v in item.items() if k != "sources"},
+                    "bonusLists":   bonus_lists,
+                    "bonus_id":     "/".join(str(b) for b in bonus_lists),
+                    "enchant_id":   enchant_id,
+                    "gem_id":       "",
+                    "instanceId":   real_inst_id,
+                    "encounterId":  enc_id,
+                    "difficulty":   difficulty,
+                    "offSpecItem":  False,
+                    "upgrade": {
+                        "group":    level_selector_seq,
+                        "level":    6,
+                        "max":      6,
+                        "name":     item_level_name,
+                        "fullName": f"{item_level_name} 6/6",
+                        "bonusId":  upgrade_bonus_id,
+                        "itemLevel": item.get("itemLevel", 276),
+                        "seasonId": 34,
+                    },
+                    "instance":    real_instance_obj,
+                    "encounter":   encounter_obj,
+                    "overrides": {
+                        "encounterId":                  enc_id,
+                        "encounterSequenceOffset":      seq_offset,
+                        "instanceId":                   real_inst_id,
+                        "difficulty":                   difficulty,
+                        "itemLevel":                    item_level_name,
+                        "levelSelectorSequence":        level_selector_seq,
+                        "season":                       season,
+                        "levelSelectorSetUpgradeTrack": True,
+                        "seasonId":                     34,
+                        "disableWarforgeLevel":         True,
+                        "enableSockets":                True,
+                        "itemConversion":               {"id": 12, "minLevel": 220},
+                        "instance":                     real_instance_obj,
+                        "encounter":                    encounter_obj,
+                        "encounterType":                "boss",
+                        "encounterTypePlural":          "bosses",
+                        "quality":                      4,
+                    },
+                    "socketInfo":    item.get("socketInfo", {}),
+                    "tooltipParams": {"enchant": enchant_id},
+                },
+            }
+            result.append(entry)
+
+    log.info(
+        "Built %d droptimizerItems for instance %s %s",
+        len(result), virtual_instance_id, difficulty,
+    )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def build_payload(
+    identity: CharacterIdentity,
+    target:   SimTarget,
+    character: dict,
+    static:   StaticData,
+) -> dict:
+    """Build a Raidbots Droptimizer submission payload.
+
+    This is a **pure function** — it performs no I/O and always produces the
+    same output for the same inputs.
+
+    Args:
+        identity:  Character name/realm/region/spec/simc.
+        target:    Simulation parameters (difficulty, spec IDs, etc.).
+        character: Raw ``/wowapi/character`` response from Raidbots.
+        static:    Pre-fetched encounter items, instances, frontend version.
+
+    Returns:
+        A ``dict`` ready to POST to ``/sim``.
+    """
+    upgrade_info = DIFFICULTY_MAP.get(target.difficulty, DIFFICULTY_MAP["raid-heroic"])
+
+    instance_data = next(
+        (i for i in static.instances if i["id"] == target.instance_id), {}
+    )
+
+    droptimizer_items = _build_droptimizer_items(
+        static.encounter_items, instance_data, target.difficulty,
+        character, upgrade_info, static.instances,
+    )
+
+    class_id = character.get("class", 8)
+    faction  = "alliance" if character.get("faction", 0) == 0 else "horde"
+
+    # Strip None and non-dict slots — Raidbots backend 500s on nil entries.
+    clean_items = {
+        k: v for k, v in character.get("items", {}).items()
+        if isinstance(v, dict)
+    }
+    character = {**character, "items": clean_items}
+
+    diff_label  = "Heroic" if target.difficulty == "raid-heroic" else "Mythic"
+    report_name = (
+        f"Droptimizer \u2022 Season 1 Raids \u2022 "
+        f"{diff_label} \u2022 {upgrade_info['itemLevel']} 6/6"
+    )
+
+    return {
+        "type":             "droptimizer",
+        "text":             identity.simc_string,
+        "baseActorName":    identity.name,
+        "spec":             identity.spec_label,
+        "armory":           {
+            "region": identity.region,
+            "realm":  identity.realm,
+            "name":   identity.name,
+        },
+        "character":        character,
+        "reportName":       report_name,
+        "frontendHost":     "www.raidbots.com",
+        "frontendVersion":  static.frontend_version,
+        "iterations":       target.iterations,
+        "fightStyle":       target.fight_style,
+        "fightLength":      300,
+        "enemyCount":       1,
+        "enemyType":        "FluffyPillow",
+        "bloodlust":        True,
+        "arcaneIntellect":  True,
+        "fortitude":        True,
+        "battleShout":      True,
+        "mysticTouch":      True,
+        "chaosBrand":       True,
+        "markOfTheWild":    True,
+        "skyfury":          True,
+        "bleeding":         True,
+        "reportDetails":    True,
+        "ptr":              False,
+        "simcVersion":      "weekly",
+        # Legacy/optional sim toggles — required by Raidbots backend
+        "aberration":                      False,
+        "apl":                             "",
+        "astralAntennaMissChance":         10,
+        "attunedToTheAether":              False,
+        "augmentation":                    "",
+        "balefireBranchRngType":           "constant",
+        "blueSilkenLining":                40,
+        "cabalistsHymnalInParty":          0,
+        "corruptingRageUptime":            80,
+        "covenantChance":                  100,
+        "cruciblePredation":               True,
+        "crucibleSustenance":              True,
+        "crucibleViolence":                True,
+        "dawnDuskThreadLining":            100,
+        "disableIqdExecute":               False,
+        "email":                           "",
+        "enableDominationShards":          False,
+        "enableRuneWords":                 False,
+        "essenceGorgerHighStat":           False,
+        "flask":                           "",
+        "food":                            "",
+        "frontendVersion":                 "aa117406d3c58c9dc83a0df039513166f66a640a",
+        "gearsets":                        [],
+        "huntersMark":                     True,
+        "iqdStatFailChance":               0,
+        "loyalToTheEndAllies":             0,
+        "nazjatar":                        False,
+        "nyalotha":                        True,
+        "ocularGlandUptime":               100,
+        "ominousChromaticEssenceAllies":   "",
+        "ominousChromaticEssencePersonal": "obsidian",
+        "potion":                          "",
+        "powerInfusion":                   False,
+        "primalRitualShell":               "wind",
+        "rubyWhelpShellTraining":          "",
+        "sendEmail":                       False,
+        "smartAggressive":                 False,
+        "smartHighPrecision":              True,
+        "soleahStatType":                  "haste",
+        "stoneLegionHeraldryInParty":      0,
+        "surgingVitality":                 0,
+        "symbioticPresence":               22,
+        "talentSets":                      [],
+        "talents":                         None,
+        "temporaryEnchant":                "",
+        "unboundChangelingStatType":       "",
+        "undulatingTides":                 100,
+        "voidRitual":                      False,
+        "whisperingIncarnateIconRoles":    "dps/heal/tank",
+        "worldveinAllies":                 0,
+        "droptimizer": {
+            "equipped":           character.get("items", {}),
+            "instance":           target.instance_id,
+            "difficulty":         target.difficulty,
+            "warforgeLevel":      0,
+            "upgradeLevel":       upgrade_info["upgradeLevel"],
+            "upgradeEquipped":    False,
+            "gem":                None,
+            "classId":            class_id,
+            "specId":             target.spec_id,
+            "lootSpecId":         target.loot_spec_id,
+            "faction":            faction,
+            "craftedStats":       target.crafted_stats,
+            "offSpecItems":       False,
+            "includeConversions": True,
+        },
+        "droptimizerItems": droptimizer_items,
+        "simOptions": {
+            "fightstyle": target.fight_style,
+            "iterations": target.iterations,
+        },
+    }

--- a/qe_sim.py
+++ b/qe_sim.py
@@ -1,0 +1,173 @@
+"""qe_sim.py — QuestionablyEpic Upgrade Finder automation for healer specs."""
+
+import logging
+import re
+from pathlib import Path
+
+from playwright.sync_api import sync_playwright, TimeoutError as PWTimeout
+
+log = logging.getLogger(__name__)
+
+QE_BASE        = "https://questionablyepic.com"
+QE_UF_URL      = QE_BASE + "/live/upgradefinder"
+QE_REPORT_URL  = QE_BASE + "/live/upgradereport/{report_id}"
+DEBUG_SHOT     = Path(__file__).parent / "qe_debug.png"
+
+# Spec IDs that should be routed to QE instead of Raidbots
+HEALER_SPEC_IDS: set[int] = {
+    65,   # Holy Paladin
+    105,  # Restoration Druid
+    256,  # Discipline Priest
+    257,  # Holy Priest
+    264,  # Restoration Shaman
+    270,  # Mistweaver Monk
+    1468, # Preservation Evoker
+}
+
+
+def is_healer(spec_id: int) -> bool:
+    return int(spec_id) in HEALER_SPEC_IDS
+
+
+def _js_click(page, locator, timeout: int = 10_000) -> None:
+    """Wait for locator to be visible, then click via page.evaluate() with
+    a raw element handle — bypasses Playwright pointer-event checks entirely."""
+    locator.wait_for(state="visible", timeout=timeout)
+    locator.scroll_into_view_if_needed(timeout=timeout)
+    handle = locator.element_handle(timeout=timeout)
+    page.evaluate("el => el.click()", handle)
+
+
+def run_qe_upgradefinder(simc: str, timeout_minutes: int = 5) -> str:
+    """
+    Automate the QE Upgrade Finder with the given SimC string.
+    Selects HEROIC and MYTHIC difficulties then clicks GO! to run the simulation
+    and returns the shareable report URL.
+
+    Raises RuntimeError if the automation fails.
+    """
+    timeout_ms = timeout_minutes * 60 * 1000
+
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch(headless=True)
+        ctx  = browser.new_context(viewport={"width": 1440, "height": 900})
+        page = ctx.new_page()
+
+        try:
+            # Block cookie/consent scripts before navigating so overlays
+            # never load and can't intercept clicks.
+            for pattern in ["**/*ncmp*", "**/*privacymanager*", "**/*cookieconsent*",
+                             "**/*consent-manager*", "**/*trustarc*", "**/*onetrust*"]:
+                page.route(pattern, lambda route: route.abort())
+
+            log.info("QE: navigating to upgrade finder...")
+            page.goto(QE_UF_URL, timeout=30_000)
+            page.wait_for_load_state("networkidle", timeout=30_000)
+
+            page.screenshot(path=str(DEBUG_SHOT))
+            log.info("QE: page loaded (screenshot saved).")
+
+            # ── Open SimC import dialog ──────────────────────────────────────
+            opened = False
+            for pattern in ["SimC", "Import", "simc", "import"]:
+                try:
+                    btn = page.get_by_role("button").filter(has_text=re.compile(pattern, re.I)).first
+                    _js_click(page, btn, timeout=5_000)
+                    page.wait_for_selector('[aria-labelledby="simc-dialog-title"]', timeout=5_000)
+                    opened = True
+                    log.info("QE: SimC dialog opened via button matching '%s'", pattern)
+                    break
+                except PWTimeout:
+                    continue
+
+            if not opened:
+                raise RuntimeError("Could not find or open the SimC import dialog on QE upgrade finder.")
+
+            # ── Fill SimC string ─────────────────────────────────────────────
+            textarea = page.locator("#simcentry")
+            textarea.wait_for(state="visible", timeout=10_000)
+            textarea.fill(simc)
+            log.info("QE: SimC string entered.")
+
+            # ── Step 1: Submit the SimC to import character/gear ─────────────
+            dialog = page.locator('[role="dialog"]')
+            try:
+                submit_btn = dialog.get_by_role("button", name=re.compile(r"^submit$", re.I))
+                _js_click(page, submit_btn, timeout=10_000)
+                log.info("QE: Submit clicked, waiting for page to process...")
+                page.wait_for_timeout(2_000)
+            except PWTimeout:
+                log.warning("QE: Submit button not found, proceeding...")
+
+            # ── Step 2: Close the dialog so we can interact with the main page ─
+            page.keyboard.press("Escape")
+            page.wait_for_timeout(500)
+            # If Escape didn't close it, click outside the dialog
+            if page.locator('[role="dialog"]').count() > 0:
+                page.mouse.click(10, 10)
+                page.wait_for_timeout(500)
+            log.info("QE: dialog closed.")
+
+            page.wait_for_timeout(1_000)
+            page.screenshot(path=str(DEBUG_SHOT))
+
+            # Dump button states so we know which are already selected
+            btn_info = page.evaluate("""() => {
+                return [...document.querySelectorAll('button')].map(b => ({
+                    text: b.innerText.trim(),
+                    cls: b.className,
+                    disabled: b.disabled
+                })).filter(b => b.text)
+            }""")
+            log.info("QE: buttons after dialog close: %s", btn_info)
+
+            # ── Step 3: Ensure HEROIC is selected ────────────────────────────
+            heroic_btn = page.locator("button").filter(has_text=re.compile(r"^\s*HEROIC\s*$", re.I)).first
+            heroic_cls = heroic_btn.get_attribute("class") or ""
+            log.info("QE: HEROIC button class before click: %s", heroic_cls)
+            _js_click(page, heroic_btn, timeout=10_000)
+            log.info("QE: HEROIC clicked.")
+            page.wait_for_timeout(300)
+            heroic_cls_after = heroic_btn.get_attribute("class") or ""
+            log.info("QE: HEROIC button class after click: %s", heroic_cls_after)
+
+            # ── Step 4: Ensure MYTHIC is selected ────────────────────────────
+            mythic_btn = page.locator("button").filter(has_text=re.compile(r"^\s*MYTHIC\s*$", re.I)).first
+            mythic_cls = mythic_btn.get_attribute("class") or ""
+            log.info("QE: MYTHIC button class before click: %s", mythic_cls)
+            _js_click(page, mythic_btn, timeout=10_000)
+            log.info("QE: MYTHIC clicked.")
+            page.wait_for_timeout(300)
+            mythic_cls_after = mythic_btn.get_attribute("class") or ""
+            log.info("QE: MYTHIC button class after click: %s", mythic_cls_after)
+
+            page.screenshot(path=str(DEBUG_SHOT))
+            log.info("QE: screenshot after difficulty selection saved.")
+
+            # ── Step 5: Click GO! ─────────────────────────────────────────────
+            go_btn = page.locator("button").filter(has_text=re.compile(r"^\s*go[!.]?\s*$", re.I)).first
+            _js_click(page, go_btn, timeout=10_000)
+            log.info("QE: GO! clicked, URL: %s", page.url)
+            page.wait_for_timeout(3_000)
+            page.screenshot(path=str(DEBUG_SHOT))
+            log.info("QE: post-GO screenshot saved, URL: %s", page.url)
+
+            # ── Wait for report URL (works for both full nav and pushState) ──
+            log.info("QE: waiting for report URL...")
+            page.wait_for_function(
+                "window.location.href.includes('upgradereport')",
+                timeout=timeout_ms,
+            )
+            report_url = page.url
+
+            # Normalise to absolute URL
+            if report_url.startswith("/"):
+                report_url = QE_BASE + report_url
+            elif not report_url.startswith("http"):
+                report_url = QE_BASE + "/" + report_url
+
+            log.info("QE: report ready → %s", report_url)
+            return report_url
+
+        finally:
+            browser.close()

--- a/raidbots_session.py
+++ b/raidbots_session.py
@@ -1,0 +1,50 @@
+"""raidbots_session.py — Centralised Raidbots HTTP session factory.
+
+Single source of truth for session creation: sets shared headers, optional
+raidsid cookie, and exposes a ``load_raidsid`` helper so callers never touch
+config.json directly for session purposes.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import requests
+
+from droptimizer import RAIDBOTS_HEADERS
+
+_DEFAULT_CONFIG = Path(__file__).parent / "config.json"
+
+
+def make_raidbots_session(
+    raidsid: str | None = None,
+    *,
+    config_path: Path = _DEFAULT_CONFIG,
+) -> requests.Session:
+    """Return a :class:`requests.Session` configured for Raidbots.
+
+    If *raidsid* is ``None`` (the default) the value is read from
+    ``config_path`` (``config.json`` next to this file).  Pass an explicit
+    empty string to skip the cookie entirely.
+
+    Args:
+        raidsid:     Raidbots session cookie value, or ``None`` to read from
+                     config.
+        config_path: Override the config file path (useful in tests).
+
+    Returns:
+        A :class:`requests.Session` with Raidbots headers and, when available,
+        the ``raidsid`` cookie set on ``www.raidbots.com``.
+    """
+    if raidsid is None:
+        try:
+            raidsid = json.loads(config_path.read_text()).get("raidsid", "")
+        except Exception:
+            raidsid = ""
+
+    s = requests.Session()
+    s.headers.update(RAIDBOTS_HEADERS)
+    if raidsid:
+        s.cookies.set("raidsid", raidsid, domain="www.raidbots.com")
+    return s

--- a/sim_router.py
+++ b/sim_router.py
@@ -1,0 +1,129 @@
+"""sim_router.py — Route simulations to the correct backend.
+
+Determines whether a spec should use Raidbots Droptimizer (DPS/tank) or
+QuestionablyEpic Upgrade Finder (healers), and provides thin wrappers that
+execute a single simulation job on the chosen backend.
+
+Playwright (used by QE) is imported lazily inside ``run_qe_sim`` so machines
+that only run DPS/tank sims never need Playwright installed.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import requests
+    from payload_builder import CharacterIdentity, SimTarget, StaticData
+
+log = logging.getLogger(__name__)
+
+# Spec IDs that should be routed to QE instead of Raidbots.
+# Kept here as the authoritative source; qe_sim.py re-exports for its own use.
+_HEALER_SPEC_IDS: frozenset[int] = frozenset({
+    65,   # Holy Paladin
+    105,  # Restoration Druid
+    256,  # Discipline Priest
+    257,  # Holy Priest
+    264,  # Restoration Shaman
+    270,  # Mistweaver Monk
+    1468, # Preservation Evoker
+})
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SimResult:
+    """Result of a single simulation run."""
+    label: str
+    url:   str
+    ok:    bool
+    error: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Routing
+# ---------------------------------------------------------------------------
+
+def backend_for(spec_id: int) -> str:
+    """Return ``"qe"`` for healer specs, ``"raidbots"`` for all others."""
+    return "qe" if int(spec_id) in _HEALER_SPEC_IDS else "raidbots"
+
+
+def is_healer(spec_id: int) -> bool:
+    """Return ``True`` if *spec_id* is a healer spec."""
+    return backend_for(spec_id) == "qe"
+
+
+# ---------------------------------------------------------------------------
+# Backend wrappers
+# ---------------------------------------------------------------------------
+
+def run_qe_sim(simc: str, label: str = "Heroic + Mythic", timeout_minutes: int = 5) -> SimResult:
+    """Run a QuestionablyEpic Upgrade Finder simulation.
+
+    Playwright is imported lazily here so callers that only run DPS sims are
+    not forced to have it installed.
+
+    Args:
+        simc:            Full SimC string for the character.
+        label:           Human-readable label for the result (default shown in
+                         the Discord/web UI).
+        timeout_minutes: How long to wait for QE to finish.
+
+    Returns:
+        A :class:`SimResult` with ``ok=True`` and the report URL on success.
+    """
+    try:
+        from qe_sim import run_qe_upgradefinder  # lazy import
+        url = run_qe_upgradefinder(simc, timeout_minutes=timeout_minutes)
+        return SimResult(label=label, url=url, ok=True)
+    except Exception as exc:
+        log.error("QE sim failed: %s", exc)
+        return SimResult(label=label, url="", ok=False, error=str(exc))
+
+
+def run_raidbots_sim(
+    session:   "requests.Session",
+    identity:  "CharacterIdentity",
+    target:    "SimTarget",
+    character: dict,
+    static:    "StaticData",
+    report_url_template: str = "https://www.raidbots.com/simbot/report/{sim_id}",
+    timeout_minutes: int = 30,
+) -> SimResult:
+    """Submit a Raidbots Droptimizer job and poll until it completes.
+
+    Args:
+        session:              An authenticated :class:`requests.Session`.
+        identity:             Character name/realm/region/spec/simc.
+        target:               Simulation parameters (difficulty, spec IDs…).
+        character:            Raw ``/wowapi/character`` response from Raidbots.
+        static:               Pre-fetched encounter items, instances, version.
+        report_url_template:  URL template with ``{sim_id}`` placeholder.
+        timeout_minutes:      How long to poll before giving up.
+
+    Returns:
+        A :class:`SimResult` with the Raidbots report URL.
+    """
+    from droptimizer import submit_job, poll_job   # lazy — avoids circular at module level
+    from payload_builder import build_payload
+
+    diff_label = "Heroic" if target.difficulty == "raid-heroic" else "Mythic"
+    label = diff_label
+
+    try:
+        payload   = build_payload(identity, target, character, static)
+        sim_id, _ = submit_job(session, payload, None)
+    except Exception as exc:
+        log.error("Raidbots submit failed: %s", exc)
+        return SimResult(label=label, url="", ok=False, error=str(exc))
+
+    ok  = poll_job(session, sim_id, timeout_minutes=timeout_minutes)
+    url = report_url_template.format(sim_id=sim_id)
+    return SimResult(label=label, url=url, ok=ok)

--- a/sim_router.py
+++ b/sim_router.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, Optional
 
 if TYPE_CHECKING:
     import requests
@@ -96,6 +96,7 @@ def run_raidbots_sim(
     static:    "StaticData",
     report_url_template: str = "https://www.raidbots.com/simbot/report/{sim_id}",
     timeout_minutes: int = 30,
+    on_submitted: Optional[Callable[[str], None]] = None,
 ) -> SimResult:
     """Submit a Raidbots Droptimizer job and poll until it completes.
 
@@ -123,6 +124,12 @@ def run_raidbots_sim(
     except Exception as exc:
         log.error("Raidbots submit failed: %s", exc)
         return SimResult(label=label, url="", ok=False, error=str(exc))
+
+    if on_submitted is not None:
+        try:
+            on_submitted(sim_id)
+        except Exception as exc:
+            log.warning("on_submitted callback raised: %s", exc)
 
     ok  = poll_job(session, sim_id, timeout_minutes=timeout_minutes)
     url = report_url_template.format(sim_id=sim_id)

--- a/simulation_runner.py
+++ b/simulation_runner.py
@@ -1,0 +1,230 @@
+"""simulation_runner.py — Unified orchestration layer for droptimizer sims.
+
+:class:`SimulationRunner` is the single entry point used by the Discord bot
+and the CLI runner.  It owns:
+
+- SimC string parsing (name, region, realm, spec, class)
+- Character preset resolution from ``characters.json``
+- Healer/DPS routing (delegates to :mod:`sim_router`)
+- Parallel job fan-out
+- Async wrapper for Discord's event loop
+
+Usage
+-----
+::
+
+    from simulation_runner import SimulationRunner, RunnerConfig
+    from sim_router import SimResult
+
+    config  = RunnerConfig(raidsid="abc…")
+    runner  = SimulationRunner(config)
+    results = runner.run(simc)          # blocking
+    results = await runner.run_async(simc)  # from async code
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+log = logging.getLogger(__name__)
+
+# Authoritative class/spec → spec_id mapping used when characters.json has no preset.
+SPEC_IDS: dict[str, dict[str, int]] = {
+    "death_knight": {"blood": 250, "frost": 251, "unholy": 252},
+    "demon_hunter": {"havoc": 577, "vengeance": 581, "devourer": 1480},
+    "druid":        {"balance": 102, "feral": 103, "guardian": 104, "restoration": 105},
+    "evoker":       {"devastation": 1467, "preservation": 1468, "augmentation": 1473},
+    "hunter":       {"beast_mastery": 253, "marksmanship": 254, "survival": 255},
+    "mage":         {"arcane": 62, "fire": 63, "frost": 64},
+    "monk":         {"brewmaster": 268, "mistweaver": 270, "windwalker": 269},
+    "paladin":      {"holy": 65, "protection": 66, "retribution": 70},
+    "priest":       {"discipline": 256, "holy": 257, "shadow": 258},
+    "rogue":        {"assassination": 259, "outlaw": 260, "subtlety": 261},
+    "shaman":       {"elemental": 262, "enhancement": 263, "restoration": 264},
+    "warlock":      {"affliction": 265, "demonology": 266, "destruction": 267},
+    "warrior":      {"arms": 71, "fury": 72, "protection": 73},
+}
+
+_DEFAULT_CHARS_PATH  = Path(__file__).parent / "characters.json"
+_DEFAULT_CONFIG_PATH = Path(__file__).parent / "config.json"
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class RunnerConfig:
+    """Immutable configuration for a :class:`SimulationRunner` instance."""
+    raidsid:         str           = ""
+    difficulties:    tuple[str, ...] = ("raid-heroic", "raid-mythic")
+    timeout_minutes: int           = 30
+
+
+# ---------------------------------------------------------------------------
+# SimC parsing helpers
+# ---------------------------------------------------------------------------
+
+def parse_simc(simc: str) -> dict:
+    """Extract ``name``, ``char_class``, ``region``, ``realm``, ``spec`` from SimC."""
+    result: dict = {}
+    for line in simc.splitlines():
+        m = re.match(r'^([\w][\w\s]*)="([^"]+)"', line)
+        if m and "char_class" not in result:
+            result["char_class"] = m.group(1).strip().lower().replace(" ", "_")
+            result["name"]       = m.group(2).strip()
+        kv = re.match(r'^(\w+)\s*=\s*(.+)', line)
+        if not kv:
+            continue
+        k, v = kv.group(1), kv.group(2).strip()
+        if k == "region": result["region"] = v.lower()
+        if k == "server": result["realm"]  = v.lower()
+        if k == "spec":   result["spec"]   = v.lower()
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+class SimulationRunner:
+    """Run all talent-build × difficulty combinations for a SimC string.
+
+    Args:
+        config:      Immutable run parameters.
+        chars_path:  Path to ``characters.json`` for preset resolution.
+                     Defaults to the file next to this module.
+    """
+
+    def __init__(
+        self,
+        config:     RunnerConfig = RunnerConfig(),
+        chars_path: Path         = _DEFAULT_CHARS_PATH,
+    ) -> None:
+        self._config     = config
+        self._chars_path = chars_path
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def run(self, simc: str) -> list:
+        """Run all sims for *simc* and return a list of :class:`~sim_router.SimResult`.
+
+        Raises :exc:`ValueError` if the SimC string cannot be parsed.
+        """
+        from sim_router import SimResult  # local to avoid circular import at module level
+        info = parse_simc(simc)
+        if not all(k in info for k in ("name", "region", "realm", "spec")):
+            raise ValueError("Could not parse name / region / realm / spec from SimC string.")
+
+        preset, spec_id, loot_spec_id, crafted_stats, simc_final = \
+            self._resolve_preset(info, simc)
+
+        from sim_router import is_healer
+        if is_healer(spec_id):
+            return self._run_healer(simc_final)
+        return self._run_dps(info, simc_final, spec_id, loot_spec_id, crafted_stats)
+
+    async def run_async(self, simc: str) -> list:
+        """Async wrapper — runs :meth:`run` in a thread-pool executor.
+
+        Suitable for use inside a Discord.py async event handler without
+        blocking the event loop.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self.run, simc)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _load_characters(self) -> list:
+        try:
+            return json.loads(self._chars_path.read_text())
+        except Exception:
+            return []
+
+    def _resolve_preset(self, info: dict, simc: str):
+        """Look up a saved preset matching name + spec."""
+        saved = {
+            (c["name"].lower(), c["spec"].lower()): c
+            for c in self._load_characters()
+        }
+        preset        = saved.get((info["name"].lower(), info["spec"].lower()))
+        spec_id       = (preset.get("spec_id")      if preset else None) or \
+                        SPEC_IDS.get(info.get("char_class", ""), {}).get(info["spec"], 63)
+        loot_spec_id  = (preset.get("loot_spec_id") if preset else None) or spec_id
+        crafted_stats = (preset.get("crafted_stats") if preset else None) or "36/49"
+        simc_final    = (preset.get("simc_string")   if preset else None) or simc
+        return preset, spec_id, loot_spec_id, crafted_stats, simc_final
+
+    def _run_healer(self, simc_final: str) -> list:
+        from droptimizer import apply_talent, find_talent_builds
+        from sim_router import run_qe_sim
+
+        talent_builds = find_talent_builds(simc_final) or {"": None}
+
+        def _qe_one(build_label: str, talent_code) -> dict:
+            sim_simc = apply_talent(simc_final, talent_code) if talent_code else simc_final
+            label    = f"Heroic + Mythic{' \u2013 ' + build_label if build_label else ''}"
+            r = run_qe_sim(sim_simc, label=label,
+                           timeout_minutes=self._config.timeout_minutes)
+            return {"label": r.label, "url": r.url, "ok": r.ok, "error": r.error}
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=len(talent_builds)) as pool:
+            futures = [pool.submit(_qe_one, bl, tc) for bl, tc in talent_builds.items()]
+            return [f.result() for f in concurrent.futures.as_completed(futures)]
+
+    def _run_dps(
+        self, info: dict, simc_final: str,
+        spec_id: int, loot_spec_id: int, crafted_stats: str,
+    ) -> list:
+        from droptimizer import apply_talent, fetch_character, fetch_static_data, find_talent_builds
+        from payload_builder import CharacterIdentity, SimTarget
+        from raidbots_session import make_raidbots_session
+        from sim_router import run_raidbots_sim
+        from droptimizer import RAIDBOTS_BASE
+
+        report_url_tmpl = RAIDBOTS_BASE + "/simbot/report/{sim_id}"
+        init_session = make_raidbots_session(self._config.raidsid)
+        static       = fetch_static_data(init_session)
+        character    = fetch_character(init_session, info["region"], info["realm"], info["name"])
+
+        talent_builds = find_talent_builds(simc_final) or {"": None}
+        jobs = [
+            (build_label, talent_code, difficulty)
+            for build_label, talent_code in talent_builds.items()
+            for difficulty in self._config.difficulties
+        ]
+
+        def _one(build_label: str, talent_code, difficulty: str) -> dict:
+            s = make_raidbots_session(self._config.raidsid)
+            sim_simc  = apply_talent(simc_final, talent_code) if talent_code else simc_final
+            diff_name = "Heroic" if difficulty == "raid-heroic" else "Mythic"
+            label     = f"{diff_name}{' \u2013 ' + build_label if build_label else ''}"
+            identity  = CharacterIdentity(
+                name=info["name"], realm=info["realm"], region=info["region"],
+                spec_label=info["spec"].capitalize(), simc_string=sim_simc,
+            )
+            target = SimTarget(
+                difficulty=difficulty,
+                spec_id=spec_id,
+                loot_spec_id=loot_spec_id,
+                crafted_stats=crafted_stats,
+            )
+            r = run_raidbots_sim(s, identity, target, character, static,
+                                 report_url_template=report_url_tmpl,
+                                 timeout_minutes=self._config.timeout_minutes)
+            return {"label": label, "url": r.url, "ok": r.ok}
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=len(jobs)) as pool:
+            futures = [pool.submit(_one, *j) for j in jobs]
+            return [f.result() for f in concurrent.futures.as_completed(futures)]

--- a/templates/index.html
+++ b/templates/index.html
@@ -79,9 +79,10 @@ input[type=checkbox] { accent-color: var(--accent); width: 15px; height: 15px; c
 .badge-running  { background: #1e2a3e; color: var(--blue); }
 .badge-done     { background: #1a3028; color: var(--green); }
 .badge-failed   { background: #3e1e1e; color: var(--red); }
-.url-chip { background: var(--surf2); border: 1px solid var(--border); border-radius: 6px; padding: 5px 10px; font-size: 12px; color: var(--acc-h); cursor: pointer; transition: all .15s; max-width: 240px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.url-chip:hover { border-color: var(--accent); background: var(--border); }
-.url-chip::before { content: '⎘ '; }
+.url-actions { display: flex; gap: 6px; align-items: center; }
+.url-btn { background: var(--surf2); border: 1px solid var(--border); border-radius: 6px; padding: 5px 10px; font-size: 12px; color: var(--acc-h); cursor: pointer; transition: all .15s; white-space: nowrap; text-decoration: none; display: inline-flex; align-items: center; gap: 4px; }
+.url-btn:hover { border-color: var(--accent); background: var(--border); color: var(--text); }
+.sim-preview { height: 56px; width: auto; border-radius: 6px; border: 1px solid var(--border); flex-shrink: 0; }
 
 /* Log */
 .log-wrap { margin-top: 4px; }
@@ -216,6 +217,12 @@ input[type=checkbox] { accent-color: var(--accent); width: 15px; height: 15px; c
         <input id="f-crafted-stats" type="text" placeholder="36/49">
       </div>
     </div>
+    <div style="margin-top:14px">
+      <label style="display:flex;align-items:center;gap:8px;font-size:12px;color:var(--sub);cursor:pointer">
+        <input type="checkbox" id="f-exclude-updates">
+        Exclude from gear updates when another profile with the same character is saved
+      </label>
+    </div>
     <div class="modal-actions">
       <button class="btn-cancel" onclick="closeModal()">Cancel</button>
       <button class="btn-primary" onclick="saveChar()">Save</button>
@@ -235,6 +242,11 @@ let logOpen = false;
 document.addEventListener('DOMContentLoaded', async () => {
   await loadChars();
   await refreshSettings();
+  // Restore last run results
+  const s = await (await fetch('/api/status')).json();
+  renderJobs(s.jobs);
+  renderLog(s.log);
+  if (s.running) startPolling();
 });
 
 // ── Characters ────────────────────────────────────────────────────────────────
@@ -245,21 +257,56 @@ async function loadChars() {
   renderSelector();
 }
 
+const GEAR_SLOTS = new Set(['head','neck','shoulder','back','chest','wrist','hands','waist','legs','feet','finger1','finger2','trinket1','trinket2','main_hand','off_hand']);
+
+function avgIlvl(simc) {
+  if (!simc) return null;
+  const ilvls = [];
+  for (const line of simc.split(/\r?\n/)) {
+    const slotMatch = line.match(/^(\w+)\s*=/);
+    if (!slotMatch || !GEAR_SLOTS.has(slotMatch[1])) continue;
+    const ilvlMatch = line.match(/\bilvl\s*=\s*(\d+)/);
+    if (ilvlMatch) ilvls.push(parseInt(ilvlMatch[1]));
+  }
+  if (!ilvls.length) return null;
+  return Math.round(ilvls.reduce((a, b) => a + b, 0) / ilvls.length);
+}
+
 function renderCharList() {
   const el = document.getElementById('chars-list');
   if (!chars.length) {
     el.innerHTML = '<div style="color:var(--sub);font-size:13px;padding:8px 8px 4px">No characters yet.</div>';
     return;
   }
-  el.innerHTML = chars.map(c => `
+  el.innerHTML = chars.map(c => {
+    const ilvl = c.ilvl || avgIlvl(c.simc_string);
+    const ilvlBadge = ilvl
+      ? ` <span style="color:var(--sub);font-size:11px;font-weight:400">· ${ilvl} ilvl</span>`
+      : ` <span id="ilvl-${c.id}" style="color:var(--sub);font-size:11px;font-weight:400"></span>`;
+    return `
     <div class="char-card">
       <div class="char-info">
-        <div class="char-name">${c.name} <span style="color:var(--accent);font-size:12px">${c.spec}</span></div>
+        <div class="char-name">${c.name} <span style="color:var(--accent);font-size:12px">${c.spec}</span>${ilvlBadge}</div>
         <div class="char-meta">${c.region.toUpperCase()} / ${c.realm}</div>
       </div>
       <button class="icon-btn" title="Edit" onclick="openModal('${c.id}')">✎</button>
       <button class="icon-btn del" title="Delete" onclick="deleteChar('${c.id}')">✕</button>
-    </div>`).join('');
+    </div>`;
+  }).join('');
+
+  // Fetch ilvl from armory for characters that don't have it cached yet
+  chars.forEach(c => {
+    if (c.ilvl || avgIlvl(c.simc_string)) return;
+    fetch(`/api/ilvl/${c.id}`)
+      .then(r => r.json())
+      .then(d => {
+        if (!d.ilvl) return;
+        c.ilvl = d.ilvl;
+        const span = document.getElementById(`ilvl-${c.id}`);
+        if (span) span.textContent = `· ${d.ilvl} ilvl`;
+      })
+      .catch(() => {});
+  });
 }
 
 function renderSelector() {
@@ -306,10 +353,10 @@ const SPEC_IDS = {
   warlock:      { affliction:265, demonology:266, destruction:267 },
   monk:         { brewmaster:268, windwalker:269, mistweaver:270 },
   druid:        { balance:102, feral:103, guardian:104, restoration:105 },
-  'demon_hunter':{ havoc:577, vengeance:581 },
+  'demon_hunter':{ havoc:577, vengeance:581, devourer:1480 },
   evoker:       { devastation:1467, preservation:1468, augmentation:1473 },
   'death knight':{ blood:250, frost:251, unholy:252 },
-  'demon hunter':{ havoc:577, vengeance:581 },
+  'demon hunter':{ havoc:577, vengeance:581, devourer:1480 },
 };
 
 function parseSimc() {
@@ -319,10 +366,18 @@ function parseSimc() {
   const lines = raw.split(/\r?\n/);
   let charName = null, charClass = null, region = null, realm = null, spec = null;
 
-  // First non-empty line: class="Name"
+  // Find class identifier line (e.g. demon_hunter="Name") — skip copy= / profileset= lines
   for (const line of lines) {
     const m = line.match(/^(\w[\w\s]*)="([^"]+)"/);
-    if (m) { charClass = m[1].trim().toLowerCase(); charName = m[2].trim(); break; }
+    if (m) {
+      const cls = m[1].trim().toLowerCase();
+      const clsNorm = cls.replace(/ /g, '_');
+      if (SPEC_IDS[cls] || SPEC_IDS[clsNorm]) {
+        charClass = clsNorm;
+        charName = m[2].trim();
+        break;
+      }
+    }
   }
 
   for (const line of lines) {
@@ -366,6 +421,7 @@ function openModal(id = null) {
   document.getElementById('f-spec-id').value      = c?.spec_id       ?? '';
   document.getElementById('f-loot-spec-id').value = c?.loot_spec_id  ?? '';
   document.getElementById('f-crafted-stats').value = c?.crafted_stats ?? '36/49';
+  document.getElementById('f-exclude-updates').checked = c?.exclude_from_item_updates ?? false;
   document.getElementById('modal-bg').classList.add('open');
   document.getElementById('f-name').focus();
 }
@@ -384,16 +440,42 @@ async function saveChar() {
     realm:         document.getElementById('f-realm').value.trim(),
     spec_id:       specId || 63,
     loot_spec_id:  parseInt(document.getElementById('f-loot-spec-id').value) || specId || 63,
-    crafted_stats: document.getElementById('f-crafted-stats').value.trim() || '36/49',
-    simc_string:   document.getElementById('f-simc').value.trim(),
+    crafted_stats:              document.getElementById('f-crafted-stats').value.trim() || '36/49',
+    simc_string:                document.getElementById('f-simc').value.trim(),
+    exclude_from_item_updates:  document.getElementById('f-exclude-updates').checked,
   };
   if (!char.name || !char.spec || !char.simc_string) {
     showToast('Name, spec and SimC string are required', true);
     return;
   }
-  await fetch('/api/characters', { method: 'POST', headers: {'Content-Type':'application/json'}, body: JSON.stringify(char) });
+
+  // Validate SimC string matches the profile name and spec
+  const simcLines = char.simc_string.split(/\r?\n/);
+  let simcName = null, simcSpec = null;
+  for (const line of simcLines) {
+    const m = line.match(/^[\w][\w\s]*="([^"]+)"/);
+    if (m) { simcName = m[1].trim(); break; }
+  }
+  for (const line of simcLines) {
+    const kv = line.match(/^spec\s*=\s*(\S+)/);
+    if (kv) { simcSpec = kv[1].trim().toLowerCase(); break; }
+  }
+  if (simcName && simcName.toLowerCase() !== char.name.toLowerCase()) {
+    showToast(`SimC mismatch: string is for "${simcName}", profile is "${char.name}"`, true);
+    return;
+  }
+  if (simcSpec && simcSpec !== char.spec.toLowerCase()) {
+    showToast(`SimC mismatch: string is ${simcSpec}, profile spec is ${char.spec}`, true);
+    return;
+  }
+
+  const resp = await fetch('/api/characters', { method: 'POST', headers: {'Content-Type':'application/json'}, body: JSON.stringify(char) });
+  const result = await resp.json();
   closeModal();
   await loadChars();
+  if (result.propagated?.length) {
+    showToast(`Gear synced to: ${result.propagated.join(', ')}`);
+  }
 }
 
 async function deleteChar(id) {
@@ -471,7 +553,11 @@ function renderJobs(jobs) {
     <div class="job-row">
       <span class="job-label">${j.label}</span>
       <span class="badge badge-${j.status}">${statusLabel(j.status)}</span>
-      ${j.url ? `<span class="url-chip" title="Click to copy" onclick="copyUrl('${j.url}')">${j.url}</span>` : ''}
+      ${j.sim_id && j.status === 'done' ? `<img class="sim-preview" src="https://www.raidbots.com/simbot/report/${j.sim_id}/preview.png" alt="preview" title="Sim preview" onerror="this.style.display='none'">` : ''}
+      ${j.url ? `<div class="url-actions">
+        <button class="url-btn" title="Copy link" onclick="copyUrl('${j.url}')">⎘ Copy</button>
+        <a class="url-btn" href="${j.url}" target="_blank" rel="noopener noreferrer">↗ Open</a>
+      </div>` : ''}
     </div>`).join('');
 }
 


### PR DESCRIPTION
## Summary

- Add `qe_sim.py`: Playwright-based QuestionablyEpic Upgrade Finder for healer specs (Holy Paladin, Disc/Holy Priest, Resto Shaman, Resto Druid, Mistweaver, Preservation Evoker)
- Add `discord_bot.py`: Discord slash command bot (`/droptimizer`) with concurrent job execution
- Integrate healer routing in `app.py`: healer specs route to QE, DPS/tank to Raidbots
- Run all sim jobs in parallel via `ThreadPoolExecutor` (was sequential)
- Persist last run state to `last_run.json`; restore jobs/log on page load
- Add gear propagation: saving a character syncs gear to other profiles with the same name
- Add `/api/ilvl` endpoint for armory ilvl lookup with caching
- UI: sim preview image + Open/Copy buttons on completed jobs, ilvl badge per character, exclude-from-gear-updates checkbox, SimC validation on save

## Test plan

- [ ] DPS character runs Raidbots Droptimizer as before
- [ ] Healer character routes to QE Upgrade Finder; mythic twin is silently skipped
- [ ] Multiple characters run in parallel (check log ordering shows concurrent activity)
- [ ] Refresh page after a run — jobs and log are restored from `last_run.json`
- [ ] Save a character with updated gear — other profiles with the same name get gear synced; toast shows which profiles were updated
- [ ] Character with `exclude_from_item_updates` checked is not affected by gear sync
- [ ] `/droptimizer` Discord slash command returns results for a DPS and healer character
- [ ] SimC string with mismatched name or spec shows validation error in modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)